### PR TITLE
Fix compilation, update to Kotlin 1.2.50

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 group=org.jetbrains.kotlinx
 version=0.0.1-SNAPSHOT
 
-kotlin_version=1.2.50-eap-100
+kotlin_version=1.2.50
 kotlin_native_version=0.7.1
 bintray_plugin_version=1.8.1-SNAPSHOT
-atomicFU_version=0.10.0-alpha
-kotlinx_coroutines_version=0.23.0
+atomicFU_version=0.10.3
+kotlinx_coroutines_version=0.23.3
 

--- a/kotlinx-io-js/src/main/kotlin/kotlinx/io/core/PacketJS.kt
+++ b/kotlinx-io-js/src/main/kotlin/kotlinx/io/core/PacketJS.kt
@@ -6,4 +6,6 @@ internal const val BUFFER_VIEW_SIZE = 4096
 
 actual fun BytePacketBuilder(headerSizeHint: Int) = BytePacketBuilder(headerSizeHint, BufferView.Pool)
 
+actual fun BytePacketBuilder() = BytePacketBuilder(0)
+
 actual class EOFException actual constructor(message: String) : Exception(message)

--- a/kotlinx-io-jvm/src/main/kotlin/kotlinx/io/core/PacketJVM.kt
+++ b/kotlinx-io-jvm/src/main/kotlin/kotlinx/io/core/PacketJVM.kt
@@ -8,6 +8,8 @@ actual val PACKET_MAX_COPY_SIZE: Int = getIOIntProperty("max.copy.size", 500)
 
 actual fun BytePacketBuilder(headerSizeHint: Int): BytePacketBuilder = BytePacketBuilder(headerSizeHint, BufferView.Pool)
 
+actual fun BytePacketBuilder(): BytePacketBuilder = BytePacketBuilder(0)
+
 @Suppress("ACTUAL_WITHOUT_EXPECT")
 actual typealias EOFException = java.io.EOFException
 

--- a/kotlinx-io-native/src/main/kotlin/kotlinx/io/core/Platform.kt
+++ b/kotlinx-io-native/src/main/kotlin/kotlinx/io/core/Platform.kt
@@ -6,4 +6,6 @@ internal const val BUFFER_VIEW_SIZE = 4096
 
 actual fun BytePacketBuilder(headerSizeHint: Int) = BytePacketBuilder(headerSizeHint, BufferView.Pool)
 
+actual fun BytePacketBuilder() = BytePacketBuilder(0)
+
 actual class EOFException actual constructor(message: String) : Exception(message)

--- a/src/main/kotlin/kotlinx/io/core/Builder.kt
+++ b/src/main/kotlin/kotlinx/io/core/Builder.kt
@@ -22,7 +22,7 @@ inline fun buildPacket(headerSizeHint: Int = 0, block: BytePacketBuilder.() -> U
 
 expect fun BytePacketBuilder(headerSizeHint: Int): BytePacketBuilder
 
-fun BytePacketBuilder(): BytePacketBuilder = BytePacketBuilder(0)
+expect fun BytePacketBuilder(): BytePacketBuilder
 
 /**
  * A builder that provides ability to build byte packets with no knowledge of it's size.


### PR DESCRIPTION
- Move BytePacketBuild() into common modules to avoid a JS name clash 
- Update to latest versions