### PR TITLE
 Update kotlinx.coroutines to 1.0.0-RC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,6 @@
 buildscript {
     repositories {
         if (kotlin_version.contains("eap") || kotlin_version.contains("-rc-") || kotlin_version.contains("-M")) {
-            maven { url 'http://dl.bintray.com/kotlin/kotlin-eap-1.1' }
-            maven { url 'http://dl.bintray.com/kotlin/kotlin-eap-1.2' }
             maven { url 'http://dl.bintray.com/kotlin/kotlin-eap' }
             maven { url 'http://dl.bintray.com/kotlin/kotlin-dev' }
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ version=0.0.1-SNAPSHOT
 kotlin_version=1.3.0-rc-131
 kotlin_native_version=1.3.0-rc-131
 bintray_plugin_version=1.8.2-SNAPSHOT
-kotlinx_coroutines_version=0.30.2-eap13
+kotlinx_coroutines_version=1.0.0-RC
 atomicFU_version=0.11.10-eap13

--- a/kotlinx-coroutines-io/kotlinx-coroutines-io-js/src/main/kotlin/kotlinx/coroutines/experimental/io/ByteChannelJS.kt
+++ b/kotlinx-coroutines-io/kotlinx-coroutines-io-js/src/main/kotlin/kotlinx/coroutines/experimental/io/ByteChannelJS.kt
@@ -75,12 +75,13 @@ actual suspend fun ByteReadChannel.copyTo(dst: ByteWriteChannel, limit: Long): L
 internal class ByteChannelJS(initial: IoBuffer, autoFlush: Boolean) : ByteChannelSequentialBase(initial, autoFlush) {
     private var attachedJob: Job? = null
 
+    @UseExperimental(InternalCoroutinesApi::class)
     override fun attachJob(job: Job) {
         attachedJob?.cancel()
         attachedJob = job
         job.invokeOnCompletion(onCancelling = true) { cause ->
             attachedJob = null
-            if (cause != null) cancel(cause)
+            if (cause != null) cancel()
         }
     }
     override suspend fun readAvailable(dst: ArrayBuffer, offset: Int, length: Int): Int {

--- a/kotlinx-coroutines-io/kotlinx-coroutines-io-jvm/src/main/kotlin/kotlinx/coroutines/experimental/io/ByteChannelSequentialJVM.kt
+++ b/kotlinx-coroutines-io/kotlinx-coroutines-io-jvm/src/main/kotlin/kotlinx/coroutines/experimental/io/ByteChannelSequentialJVM.kt
@@ -12,12 +12,13 @@ class ByteChannelSequentialJVM(initial: IoBuffer, autoFlush: Boolean)
     @Volatile
     private var attachedJob: Job? = null
 
+    @UseExperimental(InternalCoroutinesApi::class)
     override fun attachJob(job: Job) {
         attachedJob?.cancel()
         attachedJob = job
         job.invokeOnCompletion(onCancelling = true) { cause ->
             attachedJob = null
-            if (cause != null) cancel(cause)
+            if (cause != null) cancel()
         }
     }
 

--- a/kotlinx-coroutines-io/kotlinx-coroutines-io-jvm/src/main/kotlin/kotlinx/coroutines/experimental/io/internal/MutableDelegateContinuation.kt
+++ b/kotlinx-coroutines-io/kotlinx-coroutines-io-jvm/src/main/kotlin/kotlinx/coroutines/experimental/io/internal/MutableDelegateContinuation.kt
@@ -11,6 +11,8 @@ import kotlin.coroutines.intrinsics.*
  * - [T] should be neither [Throwable] nor [Continuation]
  * - value shouldn't be null
  */
+@Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE", "CANNOT_OVERRIDE_INVISIBLE_MEMBER") // yay, performance!
+@UseExperimental(InternalCoroutinesApi::class)
 internal class MutableDelegateContinuation<T : Any> : Continuation<T>, DispatchedTask<T> {
     private var _delegate: Continuation<T>? = null
     private val state = atomic<Any?>(null)

--- a/kotlinx-coroutines-io/kotlinx-coroutines-io-jvm/src/main/kotlin/kotlinx/coroutines/experimental/io/internal/Utils.kt
+++ b/kotlinx-coroutines-io/kotlinx-coroutines-io-jvm/src/main/kotlin/kotlinx/coroutines/experimental/io/internal/Utils.kt
@@ -1,5 +1,6 @@
 package kotlinx.coroutines.io.internal
 
+import kotlinx.coroutines.*
 import java.nio.*
 import java.util.concurrent.atomic.*
 import kotlin.reflect.*
@@ -22,6 +23,10 @@ internal fun getIOIntProperty(name: String, default: Int): Int =
     try { System.getProperty("kotlinx.coroutines.io.$name") }
     catch (e: SecurityException) { null }
         ?.toIntOrNull() ?: default
+
+@Suppress("INVISIBLE_MEMBER")
+internal fun <T> Result<T>.toState(): Any? =
+    if (isSuccess) getOrThrow() else CompletedExceptionally(exceptionOrNull()!!)
 
 
 @Suppress("LoopToCallChain")

--- a/kotlinx-coroutines-io/kotlinx-coroutines-io-jvm/src/main/kotlin/kotlinx/coroutines/experimental/io/jvm/javaio/Blocking.kt
+++ b/kotlinx-coroutines-io/kotlinx-coroutines-io-jvm/src/main/kotlin/kotlinx/coroutines/experimental/io/jvm/javaio/Blocking.kt
@@ -4,6 +4,7 @@ import kotlinx.atomicfu.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.io.*
+import kotlinx.coroutines.io.internal.*
 import java.io.*
 import java.util.concurrent.locks.*
 import kotlin.coroutines.*
@@ -124,7 +125,10 @@ private class OutputAdapter(parent: Job?, private val channel: ByteWriteChannel)
 }
 
 private abstract class BlockingAdapter(val parent: Job? = null) {
+
+    @UseExperimental(ExperimentalCoroutinesApi::class)
     private val end: Continuation<Unit> = object : Continuation<Unit> {
+        // TODO 1) excess allocation 2) Unconfined should be present in both code paths?
         override val context: CoroutineContext
             get() = if (parent != null) Dispatchers.Unconfined + parent else EmptyCoroutineContext
 

--- a/kotlinx-coroutines-io/kotlinx-coroutines-io-native/src/main/kotlin/kotlinx/coroutines/experimental/io/ByteChannelNative.kt
+++ b/kotlinx-coroutines-io/kotlinx-coroutines-io-native/src/main/kotlin/kotlinx/coroutines/experimental/io/ByteChannelNative.kt
@@ -54,6 +54,7 @@ internal class ByteChannelNative(initial: IoBuffer, autoFlush: Boolean) : ByteCh
     @Volatile
     private var attachedJob: Job? = null
 
+    @UseExperimental(InternalCoroutinesApi::class)
     override fun attachJob(job: Job) {
         attachedJob?.cancel()
         attachedJob = job

--- a/kotlinx-coroutines-io/src/main/kotlin/kotlinx/coroutines/experimental/io/ByteChannelCoroutine.kt
+++ b/kotlinx-coroutines-io/src/main/kotlin/kotlinx/coroutines/experimental/io/ByteChannelCoroutine.kt
@@ -3,10 +3,12 @@ package kotlinx.coroutines.io
 import kotlinx.coroutines.*
 import kotlin.coroutines.CoroutineContext
 
+@UseExperimental(InternalCoroutinesApi::class)
 internal open class ByteChannelCoroutine(
     parentContext: CoroutineContext,
     open val channel: ByteChannel
 ) : AbstractCoroutine<Unit>(parentContext, active = true) {
+    // TODO see ProducerCoroutine or ActorCoroutine, this one is prone to exception loss
     override fun onCancellation(cause: Throwable?) {
         if (!channel.close(cause) && cause != null)
             handleCoroutineException(context, cause)


### PR DESCRIPTION
...add some review comments in forms of TODO

Do not merge before 1.0.0-RC release.
I've fastly skimmed through API and here are things that caught my eye, but take it with a grain of salt because I haven't evaluated real usages of API.

- package is `kotlinx.coroutines.io`, but folder structure is `kotlinx.coroutines.experimental.io`
- it's good idea to rename package to `kotlinx.io.coroutines`to have a common prefix and avoid clashes with `koltinx.coroutines`. Also, it will help to flatten folders structure
- there is a lot of unused code/API. It should be either documented/tested, or removed (in release different from 0.0.1)
- `IoBuffer` does not have `copy` method as it stated in the documentation. Also, it is not a buffer :) `A read-write facade to actual buffer`, so this part of mental model can be revisited. Should this API be exposed as `public`?
- Naming is inconsisent, e.g. `IoBuffer`, but `ByteChannelSequentialJVM` and `decodeUTF8` (my vote for `decodeUtf8`).
- Some copy-paste between JS and Native
- Some API is prone to overflows. E.g. `fun ByteReadPacket.readBytes(n: Int = remaining.coerceAtMostMaxInt())` will break its contract if packet is larger than 2 GBs.
- Some API (such as `resetForWrite(limit: Int)`) doesn't check for `limit > 0`, but checks that `limit <= writeBuffer.capacity()`. (also, these checks are duplicated by java BB API)
- `@Deprecated(level = ERROR)` in interface seems like API flaw. E.g. what if I want to implement `DevNullInput` in my serialization benchmarks? At least provide a default implementation for these methods
- `Charset` is not documented
- `addSuppressedInt` is probably for `addSuppressedInternal`? 
- `public fun readUTFUntilDelimiterToSlow1` 