### PR TITLE
Adds a cpointer constructor to native IoBuffer

### DIFF
--- a/kotlinx-io-native/src/main/kotlin/kotlinx/io/core/IoBufferNative.kt
+++ b/kotlinx-io-native/src/main/kotlin/kotlinx/io/core/IoBufferNative.kt
@@ -17,6 +17,8 @@ actual class IoBuffer internal constructor(
 ) : Input, Output {
     internal var refCount = 1
 
+    constructor(content: CPointer<ByteVar>, contentCapacity: Int) : this(content, contentCapacity, null)
+
     internal var readPosition = 0
     internal var writePosition = 0
     private var limit = contentCapacity


### PR DESCRIPTION
so that IoBuffer can be used to read AND write on a memory chunk.