### PR TITLE
Slightly change buffer primitive operations on Native

### DIFF
--- a/core/commonMain/src/kotlinx/io/buffer/BufferOperations.kt
+++ b/core/commonMain/src/kotlinx/io/buffer/BufferOperations.kt
@@ -14,13 +14,13 @@ public inline operator fun Buffer.get(index: Int): Byte = loadByteAt(index)
  * Read byte at the specified [index].
  * May throw [IndexOutOfBoundsException] if index is negative or greater than buffer size.
  */
-public inline operator fun Buffer.get(index: Long): Byte = loadByteAt(index.toIntOrFail("index"))
+public inline operator fun Buffer.get(index: Long): Byte = loadByteAt(index)
 
 /**
  * Index write operator to write [value] at the specified [index].
  * May throw [IndexOutOfBoundsException] if index is negative or greater than buffer size.
  */
-public inline operator fun Buffer.set(index: Long, value: Byte) = storeByteAt(index.toIntOrFail("index"), value)
+public inline operator fun Buffer.set(index: Long, value: Byte): Unit = storeByteAt(index, value)
 
 /**
  * Index write operator to write [value] at the specified [index].

--- a/core/commonMain/src/kotlinx/io/buffer/PrimitivesOperations.kt
+++ b/core/commonMain/src/kotlinx/io/buffer/PrimitivesOperations.kt
@@ -2,13 +2,11 @@
 
 package kotlinx.io.buffer
 
-import kotlinx.io.internal.*
-
 /**
  * Returns byte at [index] position.
  * May throw [IndexOutOfBoundsException] if given [index] is negative or greater than buffer size.
  */
-public inline fun Buffer.loadByteAt(index: Long): Byte = loadByteAt(index.toIntOrFail("index"))
+public expect fun Buffer.loadByteAt(index: Long): Byte
 
 /**
  * Returns unsigned byte at [index] position.
@@ -28,7 +26,7 @@ public inline fun Buffer.loadUByteAt(index: Long): UByte = loadByteAt(index).toU
  * Write [value] at the specified [index].
  * May throw [IndexOutOfBoundsException] if given [index] is negative or greater than buffer size.
  */
-public inline fun Buffer.storeByteAt(index: Long, value: Byte) = storeByteAt(index.toIntOrFail("index"), value)
+public expect fun Buffer.storeByteAt(index: Long, value: Byte)
 
 /**
  * Write [value] at the specified [index].
@@ -42,55 +40,55 @@ public inline fun Buffer.storeUByteAt(index: Int, value: UByte) = storeByteAt(in
  * May throw [IndexOutOfBoundsException] if given [index] is negative or greater than buffer size.
  */
 @ExperimentalUnsignedTypes
-public inline fun Buffer.storeUByteAt(index: Long, value: UByte) = storeByteAt(index.toIntOrFail("index"), value.toByte())
+public inline fun Buffer.storeUByteAt(index: Long, value: UByte) = storeByteAt(index, value.toByte())
 
 /**
- * Read short signed 16bit integer in the network byte order (Big Endian).
+ * Read short signed 16-bit integer in the network byte order (Big Endian).
  * May throw [IndexOutOfBoundsException] if given [offset] is negative or greater than buffer size.
  */
 public expect fun Buffer.loadShortAt(offset: Int): Short
 
 /**
- * Read short signed 16bit integer in the network byte order (Big Endian).
+ * Read short signed 16-bit integer in the network byte order (Big Endian).
  * May throw [IndexOutOfBoundsException] if given [offset] is negative or greater than buffer size.
  */
 public expect fun Buffer.loadShortAt(offset: Long): Short
 
 /**
- * Write short signed 16bit integer in the network byte order (Big Endian).
+ * Write short signed 16-bit integer in the network byte order (Big Endian).
  * May throw [IndexOutOfBoundsException] if given [offset] is negative or greater than buffer size.
  */
 public expect fun Buffer.storeShortAt(offset: Int, value: Short)
 
 /**
- * Write short signed 16bit integer in the network byte order (Big Endian).
+ * Write short signed 16-bit integer in the network byte order (Big Endian).
  * May throw [IndexOutOfBoundsException] if given [offset] is negative or greater than buffer size.
  */
 public expect fun Buffer.storeShortAt(offset: Long, value: Short)
 
 /**
- * Read short unsigned 16bit integer in the network byte order (Big Endian).
+ * Read short unsigned 16-bit integer in the network byte order (Big Endian).
  * May throw [IndexOutOfBoundsException] if given [offset] is negative or greater than buffer size.
  */
 @ExperimentalUnsignedTypes
 public inline fun Buffer.loadUShortAt(offset: Int): UShort = loadShortAt(offset).toUShort()
 
 /**
- * Read short unsigned 16bit integer in the network byte order (Big Endian).
+ * Read short unsigned 16-bit integer in the network byte order (Big Endian).
  * May throw [IndexOutOfBoundsException] if given [offset] is negative or greater than buffer size.
  */
 @ExperimentalUnsignedTypes
 public inline fun Buffer.loadUShortAt(offset: Long): UShort = loadShortAt(offset).toUShort()
 
 /**
- * Write short unsigned 16bit integer in the network byte order (Big Endian).
+ * Write short unsigned 16-bit integer in the network byte order (Big Endian).
  * May throw [IndexOutOfBoundsException] if given [offset] is negative or greater than buffer size.
  */
 @ExperimentalUnsignedTypes
 public inline fun Buffer.storeUShortAt(offset: Int, value: UShort): Unit = storeShortAt(offset, value.toShort())
 
 /**
- * Write short unsigned 16bit integer in the network byte order (Big Endian).
+ * Write short unsigned 16-bit integer in the network byte order (Big Endian).
  * May throw [IndexOutOfBoundsException] if given [offset] is negative or greater than buffer size.
  */
 @ExperimentalUnsignedTypes

--- a/core/commonTest/src/kotlinx/io/tests/Platform.kt
+++ b/core/commonTest/src/kotlinx/io/tests/Platform.kt
@@ -1,0 +1,11 @@
+package kotlinx.io.tests
+
+enum class Platform {
+    JVM,
+    NATIVE,
+    JS
+}
+
+expect val platform: Platform
+
+val isNative: Boolean get() = platform == Platform.NATIVE

--- a/core/commonTest/src/kotlinx/io/tests/buffer/BufferExceptionsTest.kt
+++ b/core/commonTest/src/kotlinx/io/tests/buffer/BufferExceptionsTest.kt
@@ -1,140 +1,217 @@
 package kotlinx.io.tests.buffer
 
 import kotlinx.io.buffer.*
+import kotlinx.io.tests.*
 import kotlin.test.*
 
 class BufferExceptionsTest {
-
+    // Note: Buffer on K/N is long-addressed
     @Test
     fun outOfBoundsOperator() {
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY[0] = 1 }
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY[0] }
-        assertFailsWith<IllegalArgumentException> { Buffer.EMPTY[Long.MAX_VALUE / 2 + 1] }
+        if (isNative) {
+            assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY[Long.MAX_VALUE / 2 + 1] }
+        } else {
+            assertFailsWith<IllegalArgumentException> { Buffer.EMPTY[Long.MAX_VALUE / 2 + 1] }
+        }
     }
 
     @Test
     fun outOfBoundsLoadDoubleAt() {
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadDoubleAt(-1) }
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadDoubleAt(-1L) }
-        assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.loadDoubleAt(Long.MAX_VALUE / 2 + 1) }
+        if (isNative) {
+            assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadDoubleAt(Long.MAX_VALUE / 2 + 1) }
+        } else {
+            assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.loadDoubleAt(Long.MAX_VALUE / 2 + 1) }
+        }
     }
 
     @Test
     fun outOfBoundsLoadFloatAt() {
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadFloatAt(-1) }
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadFloatAt(-1L) }
-        assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.loadFloatAt(Long.MAX_VALUE / 2 + 1) }
+        if (isNative) {
+            assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadFloatAt(Long.MAX_VALUE / 2 + 1) }
+        } else {
+            assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.loadFloatAt(Long.MAX_VALUE / 2 + 1) }
+        }
     }
 
     @Test
     fun outOfBoundsLoadIntAt() {
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadIntAt(-1) }
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadIntAt(-1L) }
-        assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.loadIntAt(Long.MAX_VALUE / 2 + 1) }
+        if (isNative) {
+            assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadIntAt(Long.MAX_VALUE / 2 + 1) }
+        } else {
+            assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.loadIntAt(Long.MAX_VALUE / 2 + 1) }
+        }
     }
 
     @Test
     fun outOfBoundsLoadLongAt() {
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadLongAt(-1) }
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadLongAt(-1L) }
-        assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.loadLongAt(Long.MAX_VALUE / 2 + 1) }
+        if (isNative) {
+            assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadLongAt(Long.MAX_VALUE / 2 + 1) }
+        } else {
+            assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.loadLongAt(Long.MAX_VALUE / 2 + 1) }
+        }
     }
 
     @Test
     fun outOfBoundsLoadShortAt() {
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadShortAt(-1) }
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadShortAt(-1L) }
-        assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.loadShortAt(Long.MAX_VALUE / 2 + 1) }
+        if (isNative) {
+            assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadShortAt(Long.MAX_VALUE / 2 + 1) }
+        } else {
+            assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.loadShortAt(Long.MAX_VALUE / 2 + 1) }
+        }
     }
 
     @Test
     fun outOfBoundsLoadUByteAt() {
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadUByteAt(-1) }
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadUByteAt(-1L) }
-        assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.loadUByteAt(Long.MAX_VALUE / 2 + 1) }
+        if (isNative) {
+            assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadUByteAt(Long.MAX_VALUE / 2 + 1) }
+        } else {
+            assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.loadUByteAt(Long.MAX_VALUE / 2 + 1) }
+        }
     }
 
     @Test
     fun outOfBoundsLoadUIntAt() {
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadUIntAt(-1) }
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadUIntAt(-1L) }
-        assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.loadUIntAt(Long.MAX_VALUE / 2 + 1) }
+        if (isNative) {
+            assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadUIntAt(Long.MAX_VALUE / 2 + 1) }
+        } else {
+            assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.loadUIntAt(Long.MAX_VALUE / 2 + 1) }
+        }
     }
 
     @Test
     fun outOfBoundsLoadULongAt() {
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadULongAt(-1) }
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadULongAt(-1L) }
-        assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.loadULongAt(Long.MAX_VALUE / 2 + 1) }
+        if (isNative) {
+            assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadULongAt(Long.MAX_VALUE / 2 + 1) }
+        } else {
+            assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.loadULongAt(Long.MAX_VALUE / 2 + 1) }
+        }
     }
 
     @Test
     fun outOfBoundsLoadUShortAt() {
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadUShortAt(-1) }
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadUShortAt(-1L) }
-        assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.loadUShortAt(Long.MAX_VALUE / 2 + 1) }
+        if (isNative) {
+            assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.loadUShortAt(Long.MAX_VALUE / 2 + 1) }
+        } else {
+            assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.loadUShortAt(Long.MAX_VALUE / 2 + 1) }
+        }
     }
 
     @Test
     fun outOfBoundsStoreDoubleAt() {
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeDoubleAt(-1, 0.0) }
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeDoubleAt(-1L, 0.0) }
-        assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.storeDoubleAt(Long.MAX_VALUE / 2 + 1, 0.0) }
+        if (isNative) {
+            assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeDoubleAt(Long.MAX_VALUE / 2 + 1, 0.0) }
+        } else {
+            assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.storeDoubleAt(Long.MAX_VALUE / 2 + 1, 0.0) }
+        }
     }
 
     @Test
     fun outOfBoundsStoreFloatAt() {
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeFloatAt(-1, 0f) }
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeFloatAt(-1L, 0f) }
-        assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.storeFloatAt(Long.MAX_VALUE / 2 + 1, 0f) }
+        if (isNative) {
+            assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeFloatAt(Long.MAX_VALUE / 2 + 1, 0f) }
+        } else {
+            assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.storeFloatAt(Long.MAX_VALUE / 2 + 1, 0f) }
+        }
     }
 
     @Test
     fun outOfBoundsStoreIntAt() {
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeIntAt(-1, 0) }
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeIntAt(-1L, 0) }
-        assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.storeIntAt(Long.MAX_VALUE / 2 + 1, 0) }
+        if (isNative) {
+            assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeIntAt(Long.MAX_VALUE / 2 + 1, 0) }
+        } else {
+            assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.storeIntAt(Long.MAX_VALUE / 2 + 1, 0) }
+        }
     }
 
     @Test
     fun outOfBoundsStoreLongAt() {
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeLongAt(-1, 0L) }
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeLongAt(-1L, 0L) }
-        assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.storeLongAt(Long.MAX_VALUE / 2 + 1, 0L) }
+        if (isNative) {
+            assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeLongAt(Long.MAX_VALUE / 2 + 1, 0L) }
+        } else {
+            assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.storeLongAt(Long.MAX_VALUE / 2 + 1, 0L) }
+        }
     }
 
     @Test
     fun outOfBoundsStoreShortAt() {
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeShortAt(-1, 0) }
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeShortAt(-1L, 0) }
-        assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.storeShortAt(Long.MAX_VALUE / 2 + 1, 0) }
+        if (isNative) {
+            assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeShortAt(Long.MAX_VALUE / 2 + 1, 0) }
+        } else {
+            assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.storeShortAt(Long.MAX_VALUE / 2 + 1, 0) }
+        }
     }
 
     @Test
     fun outOfBoundsStoreUByteAt() {
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeUByteAt(-1, 0u) }
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeUByteAt(-1L, 0u) }
-        assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.storeUByteAt(Long.MAX_VALUE / 2 + 1, 0u) }
+        if (isNative) {
+            assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeUByteAt(Long.MAX_VALUE / 2 + 1, 0u) }
+        } else {
+            assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.storeUByteAt(Long.MAX_VALUE / 2 + 1, 0u) }
+        }
     }
 
     @Test
     fun outOfBoundsStoreUIntAt() {
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeUIntAt(-1, 0u) }
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeUIntAt(-1L, 0u) }
-        assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.storeUIntAt(Long.MAX_VALUE / 2 + 1, 0u) }
+        if (isNative) {
+            assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeUIntAt(Long.MAX_VALUE / 2 + 1, 0u) }
+        } else {
+            assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.storeUIntAt(Long.MAX_VALUE / 2 + 1, 0u) }
+        }
     }
 
     @Test
     fun outOfBoundsStoreULongAt() {
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeULongAt(-1, 0u) }
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeULongAt(-1L, 0u) }
-        assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.storeULongAt(Long.MAX_VALUE / 2 + 1, 0u) }
+        if (isNative) {
+            assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeULongAt(Long.MAX_VALUE / 2 + 1, 0u) }
+        } else {
+            assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.storeULongAt(Long.MAX_VALUE / 2 + 1, 0u) }
+        }
     }
 
     @Test
     fun outOfBoundsStoreUShortAt() {
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeUShortAt(-1, 0u) }
         assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeUShortAt(-1L, 0u) }
-        assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.storeUShortAt(Long.MAX_VALUE / 2 + 1, 0u) }
+        if (isNative) {
+            assertFailsWith<IndexOutOfBoundsException> { Buffer.EMPTY.storeUShortAt(Long.MAX_VALUE / 2 + 1, 0u) }
+        } else {
+            assertFailsWith<IllegalArgumentException> { Buffer.EMPTY.storeUShortAt(Long.MAX_VALUE / 2 + 1, 0u) }
+        }
     }
 }

--- a/core/jsMain/src/kotlinx/io/buffer/JsPrimitivesOperations.kt
+++ b/core/jsMain/src/kotlinx/io/buffer/JsPrimitivesOperations.kt
@@ -3,6 +3,8 @@ package kotlinx.io.buffer
 import kotlinx.io.internal.*
 import org.khronos.webgl.*
 
+public actual fun Buffer.loadByteAt(index: Long): Byte = loadByteAt(index.toIntOrFail("index"))
+
 public actual fun Buffer.loadShortAt(offset: Int): Short = checked(offset) {
     return view.getInt16(offset, false)
 }
@@ -113,6 +115,10 @@ public actual fun Buffer.storeDoubleAt(offset: Int, value: Double): Unit = check
  */
 public actual fun Buffer.storeDoubleAt(offset: Long, value: Double) = checked(offset) {
     view.setFloat64(it, value, littleEndian = false)
+}
+
+public actual fun Buffer.storeByteAt(index: Long, value: Byte) = checked(index) {
+    storeByteAt(it, value)
 }
 
 @PublishedApi

--- a/core/jsTest/src/kotlinx/io/tests/PlatformJs.kt
+++ b/core/jsTest/src/kotlinx/io/tests/PlatformJs.kt
@@ -1,0 +1,3 @@
+package kotlinx.io.tests
+
+actual val platform: Platform = Platform.JS

--- a/core/jvmMain/src/kotlinx/io/buffer/JvmPrimitivesOperations.kt
+++ b/core/jvmMain/src/kotlinx/io/buffer/JvmPrimitivesOperations.kt
@@ -4,6 +4,8 @@ package kotlinx.io.buffer
 
 import kotlinx.io.internal.*
 
+public actual inline fun Buffer.loadByteAt(index: Long): Byte = loadByteAt(index.toIntOrFail("index"))
+
 public actual inline fun Buffer.loadShortAt(offset: Int): Short {
     return buffer.getShort(offset)
 }
@@ -83,3 +85,5 @@ public actual inline fun Buffer.storeDoubleAt(offset: Int, value: Double) {
 public actual inline fun Buffer.storeDoubleAt(offset: Long, value: Double) {
     storeDoubleAt(offset.toIntOrFail("offset"), value)
 }
+
+public actual inline fun Buffer.storeByteAt(index: Long, value: Byte) = storeByteAt(index.toIntOrFail("index"), value)

--- a/core/jvmTest/src/kotlinx/io/tests/PlatformJvm.kt
+++ b/core/jvmTest/src/kotlinx/io/tests/PlatformJvm.kt
@@ -1,0 +1,3 @@
+package kotlinx.io.tests
+
+actual val platform: Platform = Platform.JVM

--- a/core/nativeMain/src/kotlinx/io/buffer/NativeBufferUtils.kt
+++ b/core/nativeMain/src/kotlinx/io/buffer/NativeBufferUtils.kt
@@ -9,7 +9,7 @@ import kotlin.contracts.*
 internal const val unalignedAccessSupported = UNALIGNED_ACCESS_ALLOWED == 1
 
 @PublishedApi
-internal inline fun Buffer.assertIndex(offset: Int, valueSize: Int): Int {
+internal fun Buffer.assertIndex(offset: Int, valueSize: Int): Int {
     assert(offset >= 0 && offset <= size - valueSize) {
         throw IndexOutOfBoundsException("offset $offset outside of range [0; ${size - valueSize})")
     }
@@ -17,14 +17,14 @@ internal inline fun Buffer.assertIndex(offset: Int, valueSize: Int): Int {
 }
 
 @PublishedApi
-internal inline fun Buffer.assertIndex(offset: Long, valueSize: Long): Long {
+internal  fun Buffer.assertIndex(offset: Long, valueSize: Long): Long {
     assert(offset >= 0 && offset <= size - valueSize) {
         throw IndexOutOfBoundsException("offset $offset outside of range [0; ${size - valueSize})")
     }
     return offset
 }
 
-internal inline fun requirePositiveIndex(value: Int, name: String) {
+internal fun requirePositiveIndex(value: Int, name: String) {
     if (value < 0) {
         throw IndexOutOfBoundsException("$name shouldn't be negative: $value")
     }

--- a/core/nativeMain/src/kotlinx/io/buffer/NativePrimitivesOperations.kt
+++ b/core/nativeMain/src/kotlinx/io/buffer/NativePrimitivesOperations.kt
@@ -3,9 +3,12 @@
 package kotlinx.io.buffer
 
 import kotlinx.cinterop.*
+import kotlinx.io.internal.*
 import kotlin.experimental.*
 
-actual inline fun Buffer.loadShortAt(offset: Int): Short {
+public actual fun Buffer.loadByteAt(index: Long): Byte = pointer[assertIndex(index, 1)]
+
+public actual fun Buffer.loadShortAt(offset: Int): Short {
     assertIndex(offset, 2)
     val pointer = pointer.plus(offset)!!
 
@@ -13,31 +16,35 @@ actual inline fun Buffer.loadShortAt(offset: Int): Short {
     else loadShortSlowAt(pointer)
 }
 
-actual inline fun Buffer.loadShortAt(offset: Long): Short {
+public actual fun Buffer.loadShortAt(offset: Long): Short {
     assertIndex(offset, 2)
     val pointer = pointer.plus(offset)!!
-
     return if (unalignedAccessSupported) pointer.reinterpret<ShortVar>().pointed.value.toBigEndian()
     else loadShortSlowAt(pointer)
 }
 
-actual inline fun Buffer.loadIntAt(offset: Int): Int {
+public actual fun Buffer.loadIntAt(offset: Int): Int {
     assertIndex(offset, 4)
     val pointer = pointer.plus(offset)!!
-
     return if (unalignedAccessSupported) pointer.reinterpret<IntVar>().pointed.value.toBigEndian()
     else loadIntSlowAt(pointer)
 }
 
-actual inline fun Buffer.loadIntAt(offset: Long): Int {
+public actual fun Buffer.loadIntAt(offset: Long): Int {
     assertIndex(offset, 4)
     val pointer = pointer.plus(offset)!!
-
     return if (unalignedAccessSupported) pointer.reinterpret<IntVar>().pointed.value.toBigEndian()
     else loadIntSlowAt(pointer)
 }
 
-actual inline fun Buffer.loadLongAt(offset: Int): Long {
+public actual fun Buffer.loadLongAt(offset: Int): Long {
+    assertIndex(offset, 8)
+    val pointer = pointer.plus(offset)!!
+    return if (unalignedAccessSupported) pointer.reinterpret<LongVar>().pointed.value.toBigEndian()
+    else loadLongSlowAt(pointer)
+}
+
+public actual fun Buffer.loadLongAt(offset: Long): Long {
     assertIndex(offset, 8)
     val pointer = pointer.plus(offset)!!
 
@@ -45,15 +52,7 @@ actual inline fun Buffer.loadLongAt(offset: Int): Long {
     else loadLongSlowAt(pointer)
 }
 
-actual inline fun Buffer.loadLongAt(offset: Long): Long {
-    assertIndex(offset, 8)
-    val pointer = pointer.plus(offset)!!
-
-    return if (unalignedAccessSupported) pointer.reinterpret<LongVar>().pointed.value.toBigEndian()
-    else loadLongSlowAt(pointer)
-}
-
-actual inline fun Buffer.loadFloatAt(offset: Int): Float {
+public actual fun Buffer.loadFloatAt(offset: Int): Float {
     assertIndex(offset, 4)
     val pointer = pointer.plus(offset)!!
 
@@ -61,37 +60,30 @@ actual inline fun Buffer.loadFloatAt(offset: Int): Float {
     else loadFloatSlowAt(pointer)
 }
 
-actual inline fun Buffer.loadFloatAt(offset: Long): Float {
+public actual fun Buffer.loadFloatAt(offset: Long): Float {
     assertIndex(offset, 4)
     val pointer = pointer.plus(offset)!!
-
     return if (unalignedAccessSupported) pointer.reinterpret<FloatVar>().pointed.value.toBigEndian()
     else loadFloatSlowAt(pointer)
 }
 
-actual inline fun Buffer.loadDoubleAt(offset: Int): Double {
+public actual fun Buffer.loadDoubleAt(offset: Int): Double {
     assertIndex(offset, 8)
     val pointer = pointer.plus(offset)!!
-
     return if (unalignedAccessSupported) pointer.reinterpret<DoubleVar>().pointed.value.toBigEndian()
     else loadDoubleSlowAt(pointer)
 }
 
-actual inline fun Buffer.loadDoubleAt(offset: Long): Double {
+public actual fun Buffer.loadDoubleAt(offset: Long): Double {
     assertIndex(offset, 8)
     val pointer = pointer.plus(offset)!!
-
     return if (unalignedAccessSupported) pointer.reinterpret<DoubleVar>().pointed.value.toBigEndian()
     else loadDoubleSlowAt(pointer)
 }
 
-/**
- * Write regular signed 32bit integer in the network byte order (Big Endian)
- */
-actual inline fun Buffer.storeIntAt(offset: Int, value: Int) {
+public actual fun Buffer.storeIntAt(offset: Int, value: Int) {
     assertIndex(offset, 4)
     val pointer = pointer.plus(offset)!!
-
     if (unalignedAccessSupported) {
         pointer.reinterpret<IntVar>().pointed.value = value.toBigEndian()
     } else {
@@ -99,13 +91,9 @@ actual inline fun Buffer.storeIntAt(offset: Int, value: Int) {
     }
 }
 
-/**
- * Write regular signed 32bit integer in the network byte order (Big Endian)
- */
-actual inline fun Buffer.storeIntAt(offset: Long, value: Int) {
+public actual fun Buffer.storeIntAt(offset: Long, value: Int) {
     assertIndex(offset, 4)
     val pointer = pointer.plus(offset)!!
-
     if (unalignedAccessSupported) {
         pointer.reinterpret<IntVar>().pointed.value = value.toBigEndian()
     } else {
@@ -113,13 +101,9 @@ actual inline fun Buffer.storeIntAt(offset: Long, value: Int) {
     }
 }
 
-/**
- * Write short signed 16bit integer in the network byte order (Big Endian)
- */
-actual inline fun Buffer.storeShortAt(offset: Int, value: Short) {
+public actual fun Buffer.storeShortAt(offset: Int, value: Short) {
     assertIndex(offset, 2)
     val pointer = pointer.plus(offset)!!
-
     if (unalignedAccessSupported) {
         pointer.reinterpret<ShortVar>().pointed.value = value.toBigEndian()
     } else {
@@ -127,13 +111,9 @@ actual inline fun Buffer.storeShortAt(offset: Int, value: Short) {
     }
 }
 
-/**
- * Write short signed 16bit integer in the network byte order (Big Endian)
- */
-actual inline fun Buffer.storeShortAt(offset: Long, value: Short) {
+public actual fun Buffer.storeShortAt(offset: Long, value: Short) {
     assertIndex(offset, 2)
     val pointer = pointer.plus(offset)!!
-
     if (unalignedAccessSupported) {
         pointer.reinterpret<ShortVar>().pointed.value = value.toBigEndian()
     } else {
@@ -141,13 +121,9 @@ actual inline fun Buffer.storeShortAt(offset: Long, value: Short) {
     }
 }
 
-/**
- * Write short signed 64bit integer in the network byte order (Big Endian)
- */
-actual inline fun Buffer.storeLongAt(offset: Int, value: Long) {
+public actual fun Buffer.storeLongAt(offset: Int, value: Long) {
     assertIndex(offset, 8)
     val pointer = pointer.plus(offset)!!
-
     if (unalignedAccessSupported) {
         pointer.reinterpret<LongVar>().pointed.value = value.toBigEndian()
     } else {
@@ -155,13 +131,9 @@ actual inline fun Buffer.storeLongAt(offset: Int, value: Long) {
     }
 }
 
-/**
- * Write short signed 64bit integer in the network byte order (Big Endian)
- */
-actual inline fun Buffer.storeLongAt(offset: Long, value: Long) {
+public actual fun Buffer.storeLongAt(offset: Long, value: Long) {
     assertIndex(offset, 8)
     val pointer = pointer.plus(offset)!!
-
     if (unalignedAccessSupported) {
         pointer.reinterpret<LongVar>().pointed.value = value.toBigEndian()
     } else {
@@ -169,10 +141,7 @@ actual inline fun Buffer.storeLongAt(offset: Long, value: Long) {
     }
 }
 
-/**
- * Write short signed 32bit floating point number in the network byte order (Big Endian)
- */
-actual inline fun Buffer.storeFloatAt(offset: Int, value: Float) {
+public actual fun Buffer.storeFloatAt(offset: Int, value: Float) {
     assertIndex(offset, 4)
     val pointer = pointer.plus(offset)!!
 
@@ -183,10 +152,7 @@ actual inline fun Buffer.storeFloatAt(offset: Int, value: Float) {
     }
 }
 
-/**
- * Write short signed 32bit floating point number in the network byte order (Big Endian)
- */
-actual inline fun Buffer.storeFloatAt(offset: Long, value: Float) {
+public actual fun Buffer.storeFloatAt(offset: Long, value: Float) {
     assertIndex(offset, 4)
     val pointer = pointer.plus(offset)!!
 
@@ -197,10 +163,7 @@ actual inline fun Buffer.storeFloatAt(offset: Long, value: Float) {
     }
 }
 
-/**
- * Write short signed 64bit floating point number in the network byte order (Big Endian)
- */
-actual inline fun Buffer.storeDoubleAt(offset: Int, value: Double) {
+public actual fun Buffer.storeDoubleAt(offset: Int, value: Double) {
     assertIndex(offset, 8)
     val pointer = pointer.plus(offset)!!
 
@@ -211,10 +174,7 @@ actual inline fun Buffer.storeDoubleAt(offset: Int, value: Double) {
     }
 }
 
-/**
- * Write short signed 64bit floating point number in the network byte order (Big Endian)
- */
-actual inline fun Buffer.storeDoubleAt(offset: Long, value: Double) {
+public actual fun Buffer.storeDoubleAt(offset: Long, value: Double) {
     assertIndex(offset, 8)
     val pointer = pointer.plus(offset)!!
 
@@ -225,22 +185,23 @@ actual inline fun Buffer.storeDoubleAt(offset: Long, value: Double) {
     }
 }
 
-@PublishedApi
-internal inline fun storeShortSlowAt(pointer: CPointer<ByteVar>, value: Short) {
+public actual fun Buffer.storeByteAt(index: Long, value: Byte) {
+    pointer[assertIndex(index, 1)] = value
+}
+
+internal fun storeShortSlowAt(pointer: CPointer<ByteVar>, value: Short) {
     pointer[0] = (value.toInt() ushr 8).toByte()
     pointer[1] = (value and 0xff).toByte()
 }
 
-@PublishedApi
-internal inline fun storeIntSlowAt(pointer: CPointer<ByteVar>, value: Int) {
+internal fun storeIntSlowAt(pointer: CPointer<ByteVar>, value: Int) {
     pointer[0] = (value ushr 24).toByte()
     pointer[1] = (value ushr 16).toByte()
     pointer[2] = (value ushr 8).toByte()
     pointer[3] = (value and 0xff).toByte()
 }
 
-@PublishedApi
-internal inline fun storeLongSlowAt(pointer: CPointer<ByteVar>, value: Long) {
+internal fun storeLongSlowAt(pointer: CPointer<ByteVar>, value: Long) {
     pointer[0] = (value ushr 56).toByte()
     pointer[1] = (value ushr 48).toByte()
     pointer[2] = (value ushr 40).toByte()
@@ -251,31 +212,26 @@ internal inline fun storeLongSlowAt(pointer: CPointer<ByteVar>, value: Long) {
     pointer[7] = (value and 0xff).toByte()
 }
 
-@PublishedApi
-internal inline fun storeFloatSlowAt(pointer: CPointer<ByteVar>, value: Float) {
+internal fun storeFloatSlowAt(pointer: CPointer<ByteVar>, value: Float) {
     storeIntSlowAt(pointer, value.toRawBits())
 }
 
-@PublishedApi
-internal inline fun storeDoubleSlowAt(pointer: CPointer<ByteVar>, value: Double) {
+internal fun storeDoubleSlowAt(pointer: CPointer<ByteVar>, value: Double) {
     storeLongSlowAt(pointer, value.toRawBits())
 }
 
-@PublishedApi
-internal inline fun loadShortSlowAt(pointer: CPointer<ByteVar>): Short {
+internal fun loadShortSlowAt(pointer: CPointer<ByteVar>): Short {
     return ((pointer[0].toInt() shl 8) or (pointer[1].toInt() and 0xff)).toShort()
 }
 
-@PublishedApi
-internal inline fun loadIntSlowAt(pointer: CPointer<ByteVar>): Int {
+internal fun loadIntSlowAt(pointer: CPointer<ByteVar>): Int {
     return ((pointer[0].toInt() shl 24) or
             (pointer[1].toInt() shl 16) or
             (pointer[2].toInt() shl 18) or
             (pointer[3].toInt() and 0xff))
 }
 
-@PublishedApi
-internal inline fun loadLongSlowAt(pointer: CPointer<ByteVar>): Long {
+internal fun loadLongSlowAt(pointer: CPointer<ByteVar>): Long {
     return ((pointer[0].toLong() shl 56) or
             (pointer[1].toLong() shl 48) or
             (pointer[2].toLong() shl 40) or
@@ -286,12 +242,10 @@ internal inline fun loadLongSlowAt(pointer: CPointer<ByteVar>): Long {
             (pointer[7].toLong() and 0xffL))
 }
 
-@PublishedApi
-internal inline fun loadFloatSlowAt(pointer: CPointer<ByteVar>): Float {
+internal fun loadFloatSlowAt(pointer: CPointer<ByteVar>): Float {
     return Float.fromBits(loadIntSlowAt(pointer))
 }
 
-@PublishedApi
-internal inline fun loadDoubleSlowAt(pointer: CPointer<ByteVar>): Double {
+internal fun loadDoubleSlowAt(pointer: CPointer<ByteVar>): Double {
     return Double.fromBits(loadLongSlowAt(pointer))
 }

--- a/core/nativeTest/src/kotlinx/io/tests/PlatformNative.kt
+++ b/core/nativeTest/src/kotlinx/io/tests/PlatformNative.kt
@@ -1,0 +1,3 @@
+package kotlinx.io.tests
+
+actual val platform: Platform = Platform.NATIVE


### PR DESCRIPTION
    * Enable long-addressing for bytes
    * Get rid of inline because primitive functions are large enough to make a negative impact
    * Make slow-paths during unaligned access non-inline for the same reasons