### PR TITLE
Introduce closeSource method to Output

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,7 @@
     - Output: Appendable
     - `Input.discard()`, discardExact
     - `readUtf8Line` throws if string ends wo `\n`
+    - Idempotent close
 - Implementation
     -  Input
     -  Output

--- a/core/commonMain/src/kotlinx/io/BytesBuilders.kt
+++ b/core/commonMain/src/kotlinx/io/BytesBuilders.kt
@@ -27,7 +27,7 @@ private class BytesOutput(bufferSize: Int = DEFAULT_BUFFER_SIZE) : Output(buffer
         bytes.append(source, length)
     }
 
-    override fun close() {
-        flush()
+    override fun closeSource() {
+        // Nothing, cannot be closed
     }
 }

--- a/core/commonMain/src/kotlinx/io/Input.kt
+++ b/core/commonMain/src/kotlinx/io/Input.kt
@@ -247,7 +247,8 @@ public abstract class Input : Closeable {
     }
 
     /**
-     * Closes the underlying source.
+     * Closes the underlying source of data used by this input.
+     * This method is invoked once the input is [closed][close].
      */
     protected abstract fun closeSource()
 

--- a/core/jsMain/src/kotlinx/io/Console.kt
+++ b/core/jsMain/src/kotlinx/io/Console.kt
@@ -31,7 +31,7 @@ private open class ConsolePrinter(private val printer: (String) -> Unit, private
         printer(decoder.decode(buffer))
     }
 
-    override fun close() {
+    override fun closeSource() {
         throw IllegalStateException("Console.$name cannot be closed")
     }
 }

--- a/core/jvmMain/src/kotlinx/io/Console.kt
+++ b/core/jvmMain/src/kotlinx/io/Console.kt
@@ -53,7 +53,7 @@ private object SystemOut : Output() {
         out.flush()
     }
 
-    override fun close() {
+    override fun closeSource() {
         throw IllegalStateException("Console.output cannot be closed")
     }
 }
@@ -69,7 +69,7 @@ private object SystemErr : Output() {
         out.flush()
     }
 
-    override fun close() {
+    override fun closeSource() {
         throw IllegalStateException("Console.error cannot be closed")
     }
 }

--- a/core/nativeMain/src/kotlinx/io/Console.kt
+++ b/core/nativeMain/src/kotlinx/io/Console.kt
@@ -43,7 +43,7 @@ public object SystemOut : Output() {
         }
     }
 
-    override fun close() {
+    override fun closeSource() {
         throw IllegalStateException("System.out cannot be closed")
     }
 }
@@ -58,7 +58,7 @@ public object SystemErr : Output() {
         }
     }
 
-    override fun close() {
+    override fun closeSource() {
         throw IllegalStateException("System.err cannot be closed")
     }
 }

--- a/playground/jvmMain/src/kotlinx/io/bytes/ByteArrayOutput.kt
+++ b/playground/jvmMain/src/kotlinx/io/bytes/ByteArrayOutput.kt
@@ -3,7 +3,7 @@ package kotlinx.io.bytes
 import kotlinx.io.*
 import kotlinx.io.buffer.*
 
-class ByteArrayOutput(initialSize: Int = 16 ) : Output() {
+class ByteArrayOutput(initialSize: Int = 16) : Output() {
     init {
         require(initialSize > 0)
     }
@@ -26,7 +26,7 @@ class ByteArrayOutput(initialSize: Int = 16 ) : Output() {
         }
     }
 
-    override fun close() {
+    override fun closeSource() {
         // Do nothing
     }
 }

--- a/playground/jvmMain/src/kotlinx/io/gzip/GzipOutput.kt
+++ b/playground/jvmMain/src/kotlinx/io/gzip/GzipOutput.kt
@@ -16,7 +16,7 @@ class GzipOutput(private val original: Output) : Output() {
        }
     }
 
-    override fun close() {
+    override fun closeSource() {
         deflater.close()
         original.writeArray(baos.toByteArray())
         original.flush()


### PR DESCRIPTION
    * Make Output.close final
    * Flush buffered data before closing the underlying source in Output.close because it is the only reasonable behaviour
    * Properly handle exceptions during termination sequence