### PR TITLE
Fixed path tests on macos-arm64

### DIFF
--- a/core/native/test/util.kt
+++ b/core/native/test/util.kt
@@ -6,16 +6,28 @@ package kotlinx.io
 
 import kotlinx.cinterop.*
 import platform.posix.*
+import kotlin.random.Random
+import kotlin.system.getTimeMillis
 
 actual fun createTempFile(): String {
     val template = "tmp-XXXXXX"
     val path = mktemp(template.cstr) ?: throw IOException("Filed to create temp file: ${strerror(errno)}")
+    // mktemp don't work on MacOS 13+ (as well as mkstemp), at least the way it's expected.
+    if (path.toKString() == "") {
+        val tmpDir = getenv("TMPDIR")?.toKString() ?: getenv("TMP")?.toKString() ?: ""
+        val rnd = Random(getTimeMillis())
+        var path: String
+        do {
+            path = "$tmpDir/tmp-${rnd.nextInt()}"
+        } while (access(path, F_OK) == 0)
+        return path
+    }
     return path.toKString()
 }
 
 actual fun deleteFile(path: String) {
     if (access(path, F_OK) != 0) throw IOException("File does not exist: $path")
     if (remove(path) != 0) {
-        throw IOException("Failed to delete file $path: ${strerror(errno)}")
+        throw IOException("Failed to delete file $path: ${strerror(errno)?.toKString()}")
     }
 }


### PR DESCRIPTION
`mktemp` returns an empty string on MacOS 13+, tried to reproduce the issue using c-program and it didn't work with template substitution there too.

As a workaround, `createTempFile` now checks what `mktemp` actually returned and substitutes a template itself in case when `mktemp` failed.