### PR TITLE
Rename string read/writeUtf8 methods

### DIFF
--- a/benchmarks/src/commonMain/kotlin/BufferOps.kt
+++ b/benchmarks/src/commonMain/kotlin/BufferOps.kt
@@ -214,8 +214,8 @@ open class Utf8StringBenchmark : BufferRWBenchmarkBase() {
     @Benchmark
     fun benchmark(): String {
         val s = buffer.size
-        buffer.writeUtf8(string)
-        return buffer.readUtf8(buffer.size - s)
+        buffer.writeString(string)
+        return buffer.readString(buffer.size - s)
     }
 }
 
@@ -257,16 +257,16 @@ open class Utf8LineBenchmarkBase : BufferRWBenchmarkBase() {
 open class Utf8LineBenchmark : Utf8LineBenchmarkBase() {
     @Benchmark
     fun benchmark(): String? {
-        buffer.writeUtf8(string)
-        return buffer.readUtf8Line()
+        buffer.writeString(string)
+        return buffer.readLine()
     }
 }
 
 open class Utf8LineStrictBenchmark : Utf8LineBenchmarkBase() {
     @Benchmark
     fun benchmark(): String {
-        buffer.writeUtf8(string)
-        return buffer.readUtf8LineStrict()
+        buffer.writeString(string)
+        return buffer.readLineStrict()
     }
 }
 

--- a/core/api/kotlinx-io-core.api
+++ b/core/api/kotlinx-io-core.api
@@ -175,14 +175,14 @@ public final class kotlinx/io/SourceExtKt {
 }
 
 public final class kotlinx/io/Utf8Kt {
-	public static final fun readUtf8 (Lkotlinx/io/Buffer;)Ljava/lang/String;
-	public static final fun readUtf8 (Lkotlinx/io/Source;)Ljava/lang/String;
-	public static final fun readUtf8 (Lkotlinx/io/Source;J)Ljava/lang/String;
-	public static final fun readUtf8Line (Lkotlinx/io/Source;)Ljava/lang/String;
-	public static final fun readUtf8LineStrict (Lkotlinx/io/Source;J)Ljava/lang/String;
-	public static synthetic fun readUtf8LineStrict$default (Lkotlinx/io/Source;JILjava/lang/Object;)Ljava/lang/String;
-	public static final fun writeUtf8 (Lkotlinx/io/Sink;Ljava/lang/String;II)V
-	public static synthetic fun writeUtf8$default (Lkotlinx/io/Sink;Ljava/lang/String;IIILjava/lang/Object;)V
+	public static final fun readLine (Lkotlinx/io/Source;)Ljava/lang/String;
+	public static final fun readLineStrict (Lkotlinx/io/Source;J)Ljava/lang/String;
+	public static synthetic fun readLineStrict$default (Lkotlinx/io/Source;JILjava/lang/Object;)Ljava/lang/String;
+	public static final fun readString (Lkotlinx/io/Buffer;)Ljava/lang/String;
+	public static final fun readString (Lkotlinx/io/Source;)Ljava/lang/String;
+	public static final fun readString (Lkotlinx/io/Source;J)Ljava/lang/String;
+	public static final fun writeString (Lkotlinx/io/Sink;Ljava/lang/String;II)V
+	public static synthetic fun writeString$default (Lkotlinx/io/Sink;Ljava/lang/String;IIILjava/lang/Object;)V
 }
 
 public final class kotlinx/io/files/Path {

--- a/core/common/src/SinkExt.kt
+++ b/core/common/src/SinkExt.kt
@@ -62,7 +62,7 @@ public fun Sink.writeDecimalLong(long: Long) {
     if (v < 0L) {
         v = -v
         if (v < 0L) { // Only true for Long.MIN_VALUE.
-            writeUtf8("-9223372036854775808")
+            writeString("-9223372036854775808")
             return
         }
         negative = true

--- a/core/common/src/SourceExt.kt
+++ b/core/common/src/SourceExt.kt
@@ -87,7 +87,7 @@ public fun Source.readDecimalLong(): Long {
                     writeByte(b)
 
                     if (!negative) readByte() // Skip negative sign.
-                    throw NumberFormatException("Number too large: ${readUtf8()}")
+                    throw NumberFormatException("Number too large: ${readString()}")
                 }
             }
             value = value * 10L + digit
@@ -143,7 +143,7 @@ public fun Source.readHexadecimalUnsignedLong(): Long {
             with(Buffer()) {
                 writeHexadecimalUnsignedLong(result)
                 writeByte(b)
-                throw NumberFormatException("Number too large: " + readUtf8())
+                throw NumberFormatException("Number too large: " + readString())
             }
         }
         result = result.shl(4) + bDigit

--- a/core/common/src/Utf8.kt
+++ b/core/common/src/Utf8.kt
@@ -72,7 +72,7 @@ package kotlinx.io
 import kotlinx.io.internal.*
 
 /**
- * Returns the number of bytes used to encode the slice of `string` as UTF-8 when using [Sink.writeUtf8].
+ * Returns the number of bytes used to encode the slice of `string` as UTF-8 when using [Sink.writeString].
  *
  * @param startIndex the index (inclusive) of the first character to encode, `0` by default.
  * @param endIndex the index (exclusive) of the character past the last character to encode, `string.length` by default.
@@ -140,7 +140,7 @@ internal fun Sink.writeUtf8CodePoint(codePoint: Int): Unit =
  * @throws IllegalStateException when the sink is closed.
  */
 @OptIn(DelicateIoApi::class)
-public fun Sink.writeUtf8(string: String, startIndex: Int = 0, endIndex: Int = string.length): Unit =
+public fun Sink.writeString(string: String, startIndex: Int = 0, endIndex: Int = string.length): Unit =
     writeToInternalBuffer { it.commonWriteUtf8(string, startIndex, endIndex) }
 
 /**
@@ -151,7 +151,7 @@ public fun Sink.writeUtf8(string: String, startIndex: Int = 0, endIndex: Int = s
  * @throws IllegalStateException when the source is closed.
  */
 @OptIn(InternalIoApi::class)
-public fun Source.readUtf8(): String {
+public fun Source.readString(): String {
     var req: Long = Segment.SIZE.toLong()
     while (request(req)) {
         req *= 2
@@ -164,7 +164,7 @@ public fun Source.readUtf8(): String {
  *
  * Returns the empty string if this buffer is empty.
  */
-public fun Buffer.readUtf8(): String {
+public fun Buffer.readString(): String {
     return commonReadUtf8(size)
 }
 
@@ -178,7 +178,7 @@ public fun Buffer.readUtf8(): String {
  * @throws IllegalStateException when the source is closed.
  */
 @OptIn(InternalIoApi::class)
-public fun Source.readUtf8(byteCount: Long): String {
+public fun Source.readString(byteCount: Long): String {
     require(byteCount)
     return buffer.commonReadUtf8(byteCount)
 }
@@ -220,7 +220,7 @@ internal fun Buffer.readUtf8CodePoint(): Int {
 }
 
 /**
- * Removes and returns characters up to but not including the next line break. A line break is
+ * Removes and returns UTF-8 encoded characters up to but not including the next line break. A line break is
  * either `"\n"` or `"\r\n"`; these characters are not included in the result.
  *
  * On the end of the stream this method returns null. If the source doesn't end with a line break, then
@@ -228,7 +228,7 @@ internal fun Buffer.readUtf8CodePoint(): Int {
  *
  * @throws IllegalStateException when the source is closed.
  */
-public fun Source.readUtf8Line(): String? {
+public fun Source.readLine(): String? {
     if (!request(1)) return null
 
     val peekSource = peek()
@@ -247,13 +247,13 @@ public fun Source.readUtf8Line(): String? {
         }
         offset++
     }
-    val line = readUtf8(offset)
+    val line = readString(offset)
     skip(newlineSize)
     return line
 }
 
 /**
- * Removes and returns characters up to but not including the next line break, throwing
+ * Removes and returns UTF-8 encoded characters up to but not including the next line break, throwing
  * [EOFException] if a line break was not encountered. A line break is either `"\n"` or `"\r\n"`;
  * these characters are not included in the result.
  *
@@ -270,7 +270,7 @@ public fun Source.readUtf8Line(): String? {
  * @throws IllegalStateException when the source is closed.
  * @throws IllegalArgumentException when [limit] is negative.
  */
-public fun Source.readUtf8LineStrict(limit: Long = Long.MAX_VALUE): String {
+public fun Source.readLineStrict(limit: Long = Long.MAX_VALUE): String {
     require(limit >= 0) { "limit ($limit) < 0" }
     require(1)
 
@@ -300,7 +300,7 @@ public fun Source.readUtf8LineStrict(limit: Long = Long.MAX_VALUE): String {
         }
     }
     if (newlineSize == 0L) throw EOFException()
-    val line = readUtf8(offset)
+    val line = readString(offset)
     skip(newlineSize)
     return line
 }

--- a/core/common/test/AbstractSourceTest.kt
+++ b/core/common/test/AbstractSourceTest.kt
@@ -88,7 +88,7 @@ abstract class AbstractBufferedSourceTest internal constructor(
 
     @Test
     fun readShortSplitAcrossMultipleSegments() {
-        sink.writeUtf8("a".repeat(Segment.SIZE - 1))
+        sink.writeString("a".repeat(Segment.SIZE - 1))
         sink.write(byteArrayOf(0xab.toByte(), 0xcd.toByte()))
         sink.emit()
         source.skip((Segment.SIZE - 1).toLong())
@@ -160,7 +160,7 @@ abstract class AbstractBufferedSourceTest internal constructor(
 
     @Test
     fun readIntSplitAcrossMultipleSegments() {
-        sink.writeUtf8("a".repeat(Segment.SIZE - 3))
+        sink.writeString("a".repeat(Segment.SIZE - 3))
         sink.write(byteArrayOf(0xab.toByte(), 0xcd.toByte(), 0xef.toByte(), 0x01.toByte()))
         sink.emit()
         source.skip((Segment.SIZE - 3).toLong())
@@ -248,7 +248,7 @@ abstract class AbstractBufferedSourceTest internal constructor(
 
     @Test
     fun readLongSplitAcrossMultipleSegments() {
-        sink.writeUtf8("a".repeat(Segment.SIZE - 7))
+        sink.writeString("a".repeat(Segment.SIZE - 7))
         sink.write(
             byteArrayOf(
                 0xab.toByte(),
@@ -292,13 +292,13 @@ abstract class AbstractBufferedSourceTest internal constructor(
     @OptIn(InternalIoApi::class)
     @Test
     fun transferTo() {
-        source.buffer.writeUtf8("abc")
-        sink.writeUtf8("def")
+        source.buffer.writeString("abc")
+        sink.writeString("def")
         sink.emit()
 
         val sink = Buffer()
         assertEquals(6, source.transferTo(sink))
-        assertEquals("abcdef", sink.readUtf8())
+        assertEquals("abcdef", sink.readString())
         assertTrue(source.exhausted())
     }
 
@@ -313,7 +313,7 @@ abstract class AbstractBufferedSourceTest internal constructor(
     @Test
     fun readExhaustedSource() {
         val sink = Buffer()
-        sink.writeUtf8("a".repeat(10))
+        sink.writeString("a".repeat(10))
         assertEquals(-1, source.readAtMostTo(sink, 10))
         assertEquals(10, sink.size)
         assertTrue(source.exhausted())
@@ -322,7 +322,7 @@ abstract class AbstractBufferedSourceTest internal constructor(
     @Test
     fun readZeroBytesFromSource() {
         val sink = Buffer()
-        sink.writeUtf8("a".repeat(10))
+        sink.writeString("a".repeat(10))
 
         // Either 0 or -1 is reasonable here. For consistency with Android's
         // ByteArrayInputStream we return 0.
@@ -394,17 +394,17 @@ abstract class AbstractBufferedSourceTest internal constructor(
 
     @Test
     fun readToSink() {
-        sink.writeUtf8("a".repeat(10000))
+        sink.writeString("a".repeat(10000))
         sink.emit()
         val sink = Buffer()
         source.readTo(sink, 9999)
-        assertEquals("a".repeat(9999), sink.readUtf8())
-        assertEquals("a", source.readUtf8())
+        assertEquals("a".repeat(9999), sink.readString())
+        assertEquals("a", source.readString())
     }
 
     @Test
     fun readToSinkTooShortThrows() {
-        sink.writeUtf8("Hi")
+        sink.writeString("Hi")
         sink.emit()
         val sink = Buffer()
         assertFailsWith<EOFException> {
@@ -412,7 +412,7 @@ abstract class AbstractBufferedSourceTest internal constructor(
         }
 
         // Verify we read all that we could from the source.
-        assertEquals("Hi", sink.readUtf8())
+        assertEquals("Hi", sink.readString())
         assertTrue(source.exhausted())
     }
 
@@ -426,19 +426,19 @@ abstract class AbstractBufferedSourceTest internal constructor(
 
     @Test
     fun readToSinkZeroBytes() {
-        sink.writeUtf8("test")
+        sink.writeString("test")
         sink.flush()
         val sink = Buffer()
         source.readTo(sink, 0)
         assertEquals(0, sink.size)
-        assertEquals("test", source.readUtf8())
+        assertEquals("test", source.readString())
     }
 
     @Test
     fun readToByteArray() {
         val data = Buffer()
-        data.writeUtf8("Hello")
-        data.writeUtf8("e".repeat(Segment.SIZE))
+        data.writeString("Hello")
+        data.writeString("e".repeat(Segment.SIZE))
 
         val expected = data.copy().readByteArray()
         sink.write(data, data.size)
@@ -456,13 +456,13 @@ abstract class AbstractBufferedSourceTest internal constructor(
 
         val sink = ByteArray(8)
 
-        buffer.writeUtf8("hello")
+        buffer.writeString("hello")
         source.readTo(sink, 0, 3)
         assertContentEquals(byteArrayOf('h'.code.toByte(), 'e'.code.toByte(), 'l'.code.toByte(), 0, 0, 0, 0, 0), sink)
-        assertEquals("lo", source.readUtf8())
+        assertEquals("lo", source.readString())
 
         sink.fill(0)
-        buffer.writeUtf8("hello")
+        buffer.writeString("hello")
         source.readTo(sink, 3)
         assertContentEquals(
             byteArrayOf(
@@ -473,10 +473,10 @@ abstract class AbstractBufferedSourceTest internal constructor(
         assertTrue(source.exhausted())
 
         sink.fill(0)
-        buffer.writeUtf8("hello")
+        buffer.writeString("hello")
         source.readTo(sink, 3, 4)
         assertContentEquals(byteArrayOf(0, 0, 0, 'h'.code.toByte(), 0, 0, 0, 0), sink)
-        assertEquals("ello", source.readUtf8())
+        assertEquals("ello", source.readString())
     }
 
     @Test
@@ -492,7 +492,7 @@ abstract class AbstractBufferedSourceTest internal constructor(
 
     @Test
     fun readToByteArrayTooShortThrows() {
-        sink.writeUtf8("Hello")
+        sink.writeString("Hello")
         sink.emit()
 
         val array = ByteArray(6)
@@ -516,7 +516,7 @@ abstract class AbstractBufferedSourceTest internal constructor(
 
     @Test
     fun readAtMostToByteArray() {
-        sink.writeUtf8("abcd")
+        sink.writeString("abcd")
         sink.emit()
 
         val sink = ByteArray(3)
@@ -534,7 +534,7 @@ abstract class AbstractBufferedSourceTest internal constructor(
 
     @Test
     fun readAtMostToByteArrayNotEnough() {
-        sink.writeUtf8("abcd")
+        sink.writeString("abcd")
         sink.emit()
 
         val sink = ByteArray(5)
@@ -553,7 +553,7 @@ abstract class AbstractBufferedSourceTest internal constructor(
 
     @Test
     fun readAtMostToByteArrayOffsetAndCount() {
-        sink.writeUtf8("abcd")
+        sink.writeString("abcd")
         sink.emit()
 
         val sink = ByteArray(7)
@@ -573,7 +573,7 @@ abstract class AbstractBufferedSourceTest internal constructor(
 
     @Test
     fun readAtMostToByteArrayFromOffset() {
-        sink.writeUtf8("abcd")
+        sink.writeString("abcd")
         sink.emit()
 
         val sink = ByteArray(7)
@@ -613,28 +613,28 @@ abstract class AbstractBufferedSourceTest internal constructor(
     @Test
     fun readByteArray() {
         val string = "abcd" + "e".repeat(Segment.SIZE)
-        sink.writeUtf8(string)
+        sink.writeString(string)
         sink.emit()
         assertArrayEquals(string.asUtf8ToByteArray(), source.readByteArray())
     }
 
     @Test
     fun readByteArrayPartial() {
-        sink.writeUtf8("abcd")
+        sink.writeString("abcd")
         sink.emit()
         assertEquals("[97, 98, 99]", source.readByteArray(3).contentToString())
-        assertEquals("d", source.readUtf8(1))
+        assertEquals("d", source.readString(1))
     }
 
     @Test
     fun readByteArrayTooShortThrows() {
-        sink.writeUtf8("abc")
+        sink.writeString("abc")
         sink.emit()
         assertFailsWith<EOFException> {
             source.readByteArray(4)
         }
 
-        assertEquals("abc", source.readUtf8()) // The read shouldn't consume any data.
+        assertEquals("abc", source.readString()) // The read shouldn't consume any data.
     }
 
     @Test
@@ -644,49 +644,49 @@ abstract class AbstractBufferedSourceTest internal constructor(
 
     @Test
     fun readUtf8SpansSegments() {
-        sink.writeUtf8("a".repeat(Segment.SIZE * 2))
+        sink.writeString("a".repeat(Segment.SIZE * 2))
         sink.emit()
         source.skip((Segment.SIZE - 1).toLong())
-        assertEquals("aa", source.readUtf8(2))
+        assertEquals("aa", source.readString(2))
     }
 
     @Test
     fun readUtf8Segment() {
-        sink.writeUtf8("a".repeat(Segment.SIZE))
+        sink.writeString("a".repeat(Segment.SIZE))
         sink.emit()
-        assertEquals("a".repeat(Segment.SIZE), source.readUtf8(Segment.SIZE.toLong()))
+        assertEquals("a".repeat(Segment.SIZE), source.readString(Segment.SIZE.toLong()))
     }
 
     @Test
     fun readUtf8PartialBuffer() {
-        sink.writeUtf8("a".repeat(Segment.SIZE + 20))
+        sink.writeString("a".repeat(Segment.SIZE + 20))
         sink.emit()
-        assertEquals("a".repeat(Segment.SIZE + 10), source.readUtf8((Segment.SIZE + 10).toLong()))
+        assertEquals("a".repeat(Segment.SIZE + 10), source.readString((Segment.SIZE + 10).toLong()))
     }
 
     @Test
     fun readUtf8EntireBuffer() {
-        sink.writeUtf8("a".repeat(Segment.SIZE * 2))
+        sink.writeString("a".repeat(Segment.SIZE * 2))
         sink.emit()
-        assertEquals("a".repeat(Segment.SIZE * 2), source.readUtf8())
+        assertEquals("a".repeat(Segment.SIZE * 2), source.readString())
     }
 
     @Test
     fun readUtf8TooShortThrows() {
-        sink.writeUtf8("abc")
+        sink.writeString("abc")
         sink.emit()
         assertFailsWith<EOFException> {
-            source.readUtf8(4L)
+            source.readString(4L)
         }
 
-        assertEquals("abc", source.readUtf8()) // The read shouldn't consume any data.
+        assertEquals("abc", source.readString()) // The read shouldn't consume any data.
     }
 
     @Test
     fun skip() {
-        sink.writeUtf8("a")
-        sink.writeUtf8("b".repeat(Segment.SIZE))
-        sink.writeUtf8("c")
+        sink.writeString("a")
+        sink.writeString("b".repeat(Segment.SIZE))
+        sink.writeString("c")
         sink.emit()
         source.skip(1)
         assertEquals('b'.code.toLong(), (source.readByte() and 0xff).toLong())
@@ -698,7 +698,7 @@ abstract class AbstractBufferedSourceTest internal constructor(
 
     @Test
     fun skipInsufficientData() {
-        sink.writeUtf8("a")
+        sink.writeString("a")
         sink.emit()
         assertFailsWith<EOFException> {
             source.skip(2)
@@ -716,13 +716,13 @@ abstract class AbstractBufferedSourceTest internal constructor(
         assertEquals(-1, source.indexOf('a'.code.toByte()))
 
         // The segment has one value.
-        sink.writeUtf8("a") // a
+        sink.writeString("a") // a
         sink.emit()
         assertEquals(0, source.indexOf('a'.code.toByte()))
         assertEquals(-1, source.indexOf('b'.code.toByte()))
 
         // The segment has lots of data.
-        sink.writeUtf8("b".repeat(Segment.SIZE - 2)) // ab...b
+        sink.writeString("b".repeat(Segment.SIZE - 2)) // ab...b
         sink.emit()
         assertEquals(0, source.indexOf('a'.code.toByte()))
         assertEquals(1, source.indexOf('b'.code.toByte()))
@@ -735,7 +735,7 @@ abstract class AbstractBufferedSourceTest internal constructor(
         assertEquals(-1, source.indexOf('c'.code.toByte()))
 
         // The segment is full.
-        sink.writeUtf8("c") // b...bc
+        sink.writeString("c") // b...bc
         sink.emit()
         assertEquals(-1, source.indexOf('a'.code.toByte()))
         assertEquals(0, source.indexOf('b'.code.toByte()))
@@ -748,7 +748,7 @@ abstract class AbstractBufferedSourceTest internal constructor(
         assertEquals((Segment.SIZE - 5).toLong(), source.indexOf('c'.code.toByte()))
 
         // Two segments.
-        sink.writeUtf8("d") // b...bcd, d is in the 2nd segment.
+        sink.writeString("d") // b...bcd, d is in the 2nd segment.
         sink.emit()
         assertEquals((Segment.SIZE - 4).toLong(), source.indexOf('d'.code.toByte()))
         assertEquals(-1, source.indexOf('e'.code.toByte()))
@@ -757,9 +757,9 @@ abstract class AbstractBufferedSourceTest internal constructor(
     @Test
     fun indexOfByteWithStartOffset() {
         with(sink) {
-            writeUtf8("a")
-            writeUtf8("b".repeat(Segment.SIZE))
-            writeUtf8("c")
+            writeString("a")
+            writeString("b".repeat(Segment.SIZE))
+            writeString("c")
             emit()
         }
         assertEquals(-1, source.indexOf('a'.code.toByte(), 1))
@@ -817,14 +817,14 @@ abstract class AbstractBufferedSourceTest internal constructor(
             assertEquals(-1, source.indexOf(c, p.toLong(), p.toLong()))
 
             // Reset.
-            source.readUtf8()
+            source.readString()
             bytes[p] = a
         }
     }
 
     @Test
     fun indexOfByteInvalidBoundsThrows() {
-        sink.writeUtf8("abc")
+        sink.writeString("abc")
         sink.emit()
         assertFailsWith<IllegalArgumentException>("Expected failure: fromIndex < 0") {
             source.indexOf('a'.code.toByte(), -1)
@@ -836,7 +836,7 @@ abstract class AbstractBufferedSourceTest internal constructor(
 
     @Test
     fun indexOfByteWithFromIndex() {
-        sink.writeUtf8("aaa")
+        sink.writeString("aaa")
         sink.emit()
         assertEquals(0, source.indexOf('a'.code.toByte()))
         assertEquals(0, source.indexOf('a'.code.toByte(), 0))
@@ -847,9 +847,9 @@ abstract class AbstractBufferedSourceTest internal constructor(
     @Test
     fun request() {
         with(sink) {
-            writeUtf8("a")
-            writeUtf8("b".repeat(Segment.SIZE))
-            writeUtf8("c")
+            writeString("a")
+            writeString("b".repeat(Segment.SIZE))
+            writeString("c")
             emit()
         }
         assertTrue(source.request((Segment.SIZE + 2).toLong()))
@@ -869,9 +869,9 @@ abstract class AbstractBufferedSourceTest internal constructor(
     @Test
     fun require() {
         with(sink) {
-            writeUtf8("a")
-            writeUtf8("b".repeat(Segment.SIZE))
-            writeUtf8("c")
+            writeString("a")
+            writeString("b".repeat(Segment.SIZE))
+            writeString("c")
             emit()
         }
         source.require((Segment.SIZE + 2).toLong())
@@ -914,7 +914,7 @@ abstract class AbstractBufferedSourceTest internal constructor(
     }
 
     private fun assertLongHexString(s: String, expected: Long) {
-        sink.writeUtf8(s)
+        sink.writeString(s)
         sink.emit()
         val actual = source.readHexadecimalUnsignedLong()
         assertEquals(expected, actual, "$s --> $expected")
@@ -923,8 +923,8 @@ abstract class AbstractBufferedSourceTest internal constructor(
     @Test
     fun longHexStringAcrossSegment() {
         with(sink) {
-            writeUtf8("a".repeat(Segment.SIZE - 8))
-            writeUtf8("FFFFFFFFFFFFFFFF")
+            writeString("a".repeat(Segment.SIZE - 8))
+            writeString("FFFFFFFFFFFFFFFF")
             emit()
         }
         source.skip((Segment.SIZE - 8).toLong())
@@ -933,17 +933,17 @@ abstract class AbstractBufferedSourceTest internal constructor(
 
     @Test
     fun longHexTerminatedByNonDigit() {
-        sink.writeUtf8("abcd,")
+        sink.writeString("abcd,")
         sink.emit()
         assertEquals(0xabcdL, source.readHexadecimalUnsignedLong())
     }
 
     @Test
     fun longHexAlphabet() {
-        sink.writeUtf8("7896543210abcdef")
+        sink.writeString("7896543210abcdef")
         sink.emit()
         assertEquals(0x7896543210abcdefL, source.readHexadecimalUnsignedLong())
-        sink.writeUtf8("ABCDEF")
+        sink.writeString("ABCDEF")
         sink.emit()
         assertEquals(0xabcdefL, source.readHexadecimalUnsignedLong())
     }
@@ -951,31 +951,31 @@ abstract class AbstractBufferedSourceTest internal constructor(
     @Test
     fun longHexStringTooLongThrows() {
         val value = "fffffffffffffffff"
-        sink.writeUtf8(value)
+        sink.writeString(value)
         sink.emit()
 
         val e = assertFailsWith<NumberFormatException> {
             source.readHexadecimalUnsignedLong()
         }
         assertEquals("Number too large: fffffffffffffffff", e.message)
-        assertEquals(value, source.readUtf8())
+        assertEquals(value, source.readString())
     }
 
     @Test
     fun longHexStringTooShortThrows() {
-        sink.writeUtf8(" ")
+        sink.writeString(" ")
         sink.emit()
 
         val e = assertFailsWith<NumberFormatException> {
             source.readHexadecimalUnsignedLong()
         }
         assertEquals("Expected leading [0-9a-fA-F] character but was 0x20", e.message)
-        assertEquals(" ", source.readUtf8())
+        assertEquals(" ", source.readString())
     }
 
     @Test
     fun longHexEmptySourceThrows() {
-        sink.writeUtf8("")
+        sink.writeString("")
         sink.emit()
         assertFailsWith<EOFException> { source.readHexadecimalUnsignedLong() }
     }
@@ -993,81 +993,81 @@ abstract class AbstractBufferedSourceTest internal constructor(
     }
 
     private fun assertLongDecimalString(s: String, expected: Long) {
-        sink.writeUtf8(s)
-        sink.writeUtf8("zzz")
+        sink.writeString(s)
+        sink.writeString("zzz")
         sink.emit()
         val actual = source.readDecimalLong()
         assertEquals(expected, actual, "$s --> $expected")
-        assertEquals("zzz", source.readUtf8())
+        assertEquals("zzz", source.readString())
     }
 
     @Test
     fun longDecimalStringAcrossSegment() {
         with(sink) {
-            writeUtf8("a".repeat(Segment.SIZE - 8))
-            writeUtf8("1234567890123456")
-            writeUtf8("zzz")
+            writeString("a".repeat(Segment.SIZE - 8))
+            writeString("1234567890123456")
+            writeString("zzz")
             emit()
         }
         source.skip((Segment.SIZE - 8).toLong())
         assertEquals(1234567890123456L, source.readDecimalLong())
-        assertEquals("zzz", source.readUtf8())
+        assertEquals("zzz", source.readString())
     }
 
     @Test
     fun longDecimalStringTooLongThrows() {
         val value = "12345678901234567890"
-        sink.writeUtf8(value) // Too many digits.
+        sink.writeString(value) // Too many digits.
         sink.emit()
 
         val e = assertFailsWith<NumberFormatException> {
             source.readDecimalLong()
         }
         assertEquals("Number too large: 12345678901234567890", e.message)
-        assertEquals(value, source.readUtf8())
+        assertEquals(value, source.readString())
     }
 
     @Test
     fun longDecimalStringTooHighThrows() {
         val value = "9223372036854775808"
-        sink.writeUtf8(value) // Right size but cannot fit.
+        sink.writeString(value) // Right size but cannot fit.
         sink.emit()
 
         val e = assertFailsWith<NumberFormatException> {
             source.readDecimalLong()
         }
         assertEquals("Number too large: 9223372036854775808", e.message)
-        assertEquals(value, source.readUtf8())
+        assertEquals(value, source.readString())
     }
 
     @Test
     fun longDecimalStringTooLowThrows() {
         val value = "-9223372036854775809"
-        sink.writeUtf8(value) // Right size but cannot fit.
+        sink.writeString(value) // Right size but cannot fit.
         sink.emit()
 
         val e = assertFailsWith<NumberFormatException> {
             source.readDecimalLong()
         }
         assertEquals("Number too large: -9223372036854775809", e.message)
-        assertEquals(value, source.readUtf8())
+        assertEquals(value, source.readString())
     }
 
     @Test
     fun longDecimalStringTooShortThrows() {
-        sink.writeUtf8(" ")
+        sink.writeString(" ")
         sink.emit()
 
         val e = assertFailsWith<NumberFormatException> {
             source.readDecimalLong()
         }
         assertEquals("Expected a digit or '-' but was 0x20", e.message)
-        assertEquals(" ", source.readUtf8())
+        assertEquals(" ", source.readString())
     }
 
     @Test
     fun longDecimalEmptyThrows() {
-        sink.writeUtf8("")
+        sink.writeString("")
         sink.emit()
         assertFailsWith<EOFException> {
             source.readDecimalLong()
@@ -1076,22 +1076,22 @@ abstract class AbstractBufferedSourceTest internal constructor(
 
     @Test
     fun longDecimalLoneDashThrows() {
-        sink.writeUtf8("-")
+        sink.writeString("-")
         sink.emit()
         assertFailsWith<EOFException> {
             source.readDecimalLong()
         }
-        assertEquals("-", source.readUtf8())
+        assertEquals("-", source.readString())
     }
 
     @Test
     fun longDecimalDashFollowedByNonDigitThrows() {
-        sink.writeUtf8("- ")
+        sink.writeString("- ")
         sink.emit()
         assertFailsWith<NumberFormatException> {
             source.readDecimalLong()
         }
-        assertEquals("- ", source.readUtf8())
+        assertEquals("- ", source.readString())
     }
 
     @Test
@@ -1154,39 +1154,39 @@ abstract class AbstractBufferedSourceTest internal constructor(
 
     @Test
     fun peek() {
-        sink.writeUtf8("abcdefghi")
+        sink.writeString("abcdefghi")
         sink.emit()
 
-        assertEquals("abc", source.readUtf8(3))
+        assertEquals("abc", source.readString(3))
 
         val peek = source.peek()
-        assertEquals("def", peek.readUtf8(3))
-        assertEquals("ghi", peek.readUtf8(3))
+        assertEquals("def", peek.readString(3))
+        assertEquals("ghi", peek.readString(3))
         assertFalse(peek.request(1))
 
-        assertEquals("def", source.readUtf8(3))
+        assertEquals("def", source.readString(3))
     }
 
     @Test
     fun peekMultiple() {
-        sink.writeUtf8("abcdefghi")
+        sink.writeString("abcdefghi")
         sink.emit()
 
-        assertEquals("abc", source.readUtf8(3))
+        assertEquals("abc", source.readString(3))
 
         val peek1 = source.peek()
         val peek2 = source.peek()
 
-        assertEquals("def", peek1.readUtf8(3))
+        assertEquals("def", peek1.readString(3))
 
-        assertEquals("def", peek2.readUtf8(3))
-        assertEquals("ghi", peek2.readUtf8(3))
+        assertEquals("def", peek2.readString(3))
+        assertEquals("ghi", peek2.readString(3))
         assertFalse(peek2.request(1))
 
-        assertEquals("ghi", peek1.readUtf8(3))
+        assertEquals("ghi", peek1.readString(3))
         assertFalse(peek1.request(1))
 
-        assertEquals("def", source.readUtf8(3))
+        assertEquals("def", source.readString(3))
     }
 
     @Test
@@ -1195,40 +1195,40 @@ abstract class AbstractBufferedSourceTest internal constructor(
             // When run on CI this causes out-of-memory errors.
             return
         }
-        sink.writeUtf8("abcdef")
-        sink.writeUtf8("g".repeat(2 * Segment.SIZE))
-        sink.writeUtf8("hij")
+        sink.writeString("abcdef")
+        sink.writeString("g".repeat(2 * Segment.SIZE))
+        sink.writeString("hij")
         sink.emit()
 
-        assertEquals("abc", source.readUtf8(3))
+        assertEquals("abc", source.readString(3))
 
         val peek = source.peek()
-        assertEquals("def", peek.readUtf8(3))
+        assertEquals("def", peek.readString(3))
         peek.skip((2 * Segment.SIZE).toLong())
-        assertEquals("hij", peek.readUtf8(3))
+        assertEquals("hij", peek.readString(3))
         assertFalse(peek.request(1))
 
-        assertEquals("def", source.readUtf8(3))
+        assertEquals("def", source.readString(3))
         source.skip((2 * Segment.SIZE).toLong())
-        assertEquals("hij", source.readUtf8(3))
+        assertEquals("hij", source.readString(3))
     }
 
     @Test
     fun peekInvalid() {
-        sink.writeUtf8("abcdefghi")
+        sink.writeString("abcdefghi")
         sink.emit()
 
-        assertEquals("abc", source.readUtf8(3))
+        assertEquals("abc", source.readString(3))
 
         val peek = source.peek()
-        assertEquals("def", peek.readUtf8(3))
-        assertEquals("ghi", peek.readUtf8(3))
+        assertEquals("def", peek.readString(3))
+        assertEquals("ghi", peek.readString(3))
         assertFalse(peek.request(1))
 
-        assertEquals("def", source.readUtf8(3))
+        assertEquals("def", source.readString(3))
 
         val e = assertFailsWith<IllegalStateException> {
-            peek.readUtf8()
+            peek.readString()
         }
         assertEquals("Peek source is invalid because upstream source was used", e.message)
     }
@@ -1236,15 +1236,15 @@ abstract class AbstractBufferedSourceTest internal constructor(
     @OptIn(InternalIoApi::class)
     @Test
     fun peekSegmentThenInvalid() {
-        sink.writeUtf8("abc")
-        sink.writeUtf8("d".repeat(2 * Segment.SIZE))
+        sink.writeString("abc")
+        sink.writeString("d".repeat(2 * Segment.SIZE))
         sink.emit()
 
-        assertEquals("abc", source.readUtf8(3))
+        assertEquals("abc", source.readString(3))
 
         // Peek a little data and skip the rest of the upstream source
         val peek = source.peek()
-        assertEquals("ddd", peek.readUtf8(3))
+        assertEquals("ddd", peek.readString(3))
         source.transferTo(discardingSink())
 
         // Skip the rest of the buffered data
@@ -1260,10 +1260,10 @@ abstract class AbstractBufferedSourceTest internal constructor(
     @Test
     fun peekDoesntReadTooMuch() {
         // 6 bytes in source's buffer plus 3 bytes upstream.
-        sink.writeUtf8("abcdef")
+        sink.writeString("abcdef")
         sink.emit()
         source.require(6L)
-        sink.writeUtf8("ghi")
+        sink.writeString("ghi")
         sink.emit()
 
         val peek = source.peek()
@@ -1274,7 +1274,7 @@ abstract class AbstractBufferedSourceTest internal constructor(
             assertEquals(6, source.buffer.size)
             assertEquals(6, peek.buffer.size)
         }
-        assertEquals("abc", peek.readUtf8(3L))
+        assertEquals("abc", peek.readString(3L))
 
         // Read 3 more bytes. This exhausts the buffered data.
         assertTrue(peek.request(3))
@@ -1282,19 +1282,19 @@ abstract class AbstractBufferedSourceTest internal constructor(
             assertEquals(6, source.buffer.size)
             assertEquals(3, peek.buffer.size)
         }
-        assertEquals("def", peek.readUtf8(3L))
+        assertEquals("def", peek.readString(3L))
 
         // Read 3 more bytes. This draws new bytes.
         assertTrue(peek.request(3))
         assertEquals(9, source.buffer.size)
         assertEquals(3, peek.buffer.size)
-        assertEquals("ghi", peek.readUtf8(3L))
+        assertEquals("ghi", peek.readString(3L))
     }
 
     @OptIn(InternalIoApi::class)
     @Test
     fun factorySegmentSizes() {
-        sink.writeUtf8("abc")
+        sink.writeString("abc")
         sink.emit()
         source.require(3)
         if (factory.isOneByteAtATime) {
@@ -1306,73 +1306,73 @@ abstract class AbstractBufferedSourceTest internal constructor(
 
     @Test
     fun readUtf8Line() {
-        sink.writeUtf8("first line\nsecond line\n")
+        sink.writeString("first line\nsecond line\n")
         sink.flush()
-        assertEquals("first line", source.readUtf8Line())
-        assertEquals("second line\n", source.readUtf8())
-        assertEquals(null, source.readUtf8Line())
+        assertEquals("first line", source.readLine())
+        assertEquals("second line\n", source.readString())
+        assertEquals(null, source.readLine())
 
-        sink.writeUtf8("\nnext line\n")
+        sink.writeString("\nnext line\n")
         sink.flush()
-        assertEquals("", source.readUtf8Line())
-        assertEquals("next line", source.readUtf8Line())
+        assertEquals("", source.readLine())
+        assertEquals("next line", source.readLine())
 
-        sink.writeUtf8("There is no newline!")
+        sink.writeString("There is no newline!")
         sink.flush()
-        assertEquals("There is no newline!", source.readUtf8Line())
+        assertEquals("There is no newline!", source.readLine())
 
-        sink.writeUtf8("Wot do u call it?\r\nWindows")
+        sink.writeString("Wot do u call it?\r\nWindows")
         sink.flush()
-        assertEquals("Wot do u call it?", source.readUtf8Line())
+        assertEquals("Wot do u call it?", source.readLine())
         source.transferTo(discardingSink())
 
-        sink.writeUtf8("reo\rde\red\n")
+        sink.writeString("reo\rde\red\n")
         sink.flush()
-        assertEquals("reo\rde\red", source.readUtf8Line())
+        assertEquals("reo\rde\red", source.readLine())
     }
 
     @Test
     fun readUtf8LineStrict() {
-        sink.writeUtf8("first line\nsecond line\n")
+        sink.writeString("first line\nsecond line\n")
         sink.flush()
-        assertEquals("first line", source.readUtf8LineStrict())
-        assertEquals("second line\n", source.readUtf8())
-        assertFailsWith<EOFException> { source.readUtf8LineStrict() }
+        assertEquals("first line", source.readLineStrict())
+        assertEquals("second line\n", source.readString())
+        assertFailsWith<EOFException> { source.readLineStrict() }
 
-        sink.writeUtf8("\nnext line\n")
+        sink.writeString("\nnext line\n")
         sink.flush()
-        assertEquals("", source.readUtf8LineStrict())
-        assertEquals("next line", source.readUtf8LineStrict())
+        assertEquals("", source.readLineStrict())
+        assertEquals("next line", source.readLineStrict())
 
-        sink.writeUtf8("There is no newline!")
+        sink.writeString("There is no newline!")
         sink.flush()
-        assertFailsWith<EOFException> { source.readUtf8LineStrict() }
-        assertEquals("There is no newline!", source.readUtf8())
+        assertFailsWith<EOFException> { source.readLineStrict() }
+        assertEquals("There is no newline!", source.readString())
 
-        sink.writeUtf8("Wot do u call it?\r\nWindows")
+        sink.writeString("Wot do u call it?\r\nWindows")
         sink.flush()
-        assertEquals("Wot do u call it?", source.readUtf8LineStrict())
+        assertEquals("Wot do u call it?", source.readLineStrict())
         source.transferTo(discardingSink())
 
-        sink.writeUtf8("reo\rde\red\n")
+        sink.writeString("reo\rde\red\n")
         sink.flush()
-        assertEquals("reo\rde\red", source.readUtf8LineStrict())
+        assertEquals("reo\rde\red", source.readLineStrict())
 
-        sink.writeUtf8("line\n")
+        sink.writeString("line\n")
         sink.flush()
-        assertFailsWith<EOFException> { source.readUtf8LineStrict(3) }
-        assertEquals("line", source.readUtf8LineStrict(4))
+        assertFailsWith<EOFException> { source.readLineStrict(3) }
+        assertEquals("line", source.readLineStrict(4))
         assertTrue(source.exhausted())
 
-        sink.writeUtf8("line\r\n")
+        sink.writeString("line\r\n")
         sink.flush()
-        assertFailsWith<EOFException> { source.readUtf8LineStrict(3) }
-        assertEquals("line", source.readUtf8LineStrict(4))
+        assertFailsWith<EOFException> { source.readLineStrict(3) }
+        assertEquals("line", source.readLineStrict(4))
         assertTrue(source.exhausted())
 
-        sink.writeUtf8("line\n")
+        sink.writeString("line\n")
         sink.flush()
-        assertEquals("line", source.readUtf8LineStrict(5))
+        assertEquals("line", source.readLineStrict(5))
         assertTrue(source.exhausted())
     }
 
@@ -1543,8 +1543,8 @@ abstract class AbstractBufferedSourceTest internal constructor(
     @Test
     fun readByteString() {
         with(sink) {
-            writeUtf8("abcd")
-            writeUtf8("e".repeat(Segment.SIZE))
+            writeString("abcd")
+            writeString("e".repeat(Segment.SIZE))
             emit()
         }
         assertEquals("abcd" + "e".repeat(Segment.SIZE), source.readByteString().decodeToString())
@@ -1553,42 +1553,42 @@ abstract class AbstractBufferedSourceTest internal constructor(
     @Test
     fun readByteStringPartial() {
         with(sink) {
-            writeUtf8("abcd")
-            writeUtf8("e".repeat(Segment.SIZE))
+            writeString("abcd")
+            writeString("e".repeat(Segment.SIZE))
             emit()
         }
         assertEquals("abc", source.readByteString(3).decodeToString())
-        assertEquals("d", source.readUtf8(1))
+        assertEquals("d", source.readString(1))
     }
 
     @Test
     fun readByteStringTooShortThrows() {
-        sink.writeUtf8("abc")
+        sink.writeString("abc")
         sink.emit()
         assertFailsWith<EOFException> { source.readByteString(4) }
 
-        assertEquals("abc", source.readUtf8()) // The read shouldn't consume any data.
+        assertEquals("abc", source.readString()) // The read shouldn't consume any data.
     }
 
     @Test
     fun indexOfByteString() {
         assertEquals(-1, source.indexOf("flop".encodeToByteString()))
 
-        sink.writeUtf8("flip flop")
+        sink.writeString("flip flop")
         sink.emit()
         assertEquals(5, source.indexOf("flop".encodeToByteString()))
-        source.readUtf8() // Clear stream.
+        source.readString() // Clear stream.
 
         // Make sure we backtrack and resume searching after partial match.
-        sink.writeUtf8("hi hi hi hey")
+        sink.writeString("hi hi hi hey")
         sink.emit()
         assertEquals(3, source.indexOf("hi hi hey".encodeToByteString()))
     }
 
     @Test
     fun indexOfByteStringAtSegmentBoundary() {
-        sink.writeUtf8("a".repeat(Segment.SIZE - 1))
-        sink.writeUtf8("bcd")
+        sink.writeString("a".repeat(Segment.SIZE - 1))
+        sink.writeString("bcd")
         sink.emit()
         assertEquals(
             (Segment.SIZE - 3).toLong(),
@@ -1646,8 +1646,8 @@ abstract class AbstractBufferedSourceTest internal constructor(
 
     @Test
     fun indexOfDoesNotWrapAround() {
-        sink.writeUtf8("a".repeat(Segment.SIZE - 1))
-        sink.writeUtf8("bcd")
+        sink.writeString("a".repeat(Segment.SIZE - 1))
+        sink.writeString("bcd")
         sink.emit()
         assertEquals(-1, source.indexOf("abcda".encodeToByteString(), (Segment.SIZE - 3).toLong()))
     }
@@ -1656,13 +1656,13 @@ abstract class AbstractBufferedSourceTest internal constructor(
     fun indexOfByteStringWithOffset() {
         assertEquals(-1, source.indexOf("flop".encodeToByteString(), 1))
 
-        sink.writeUtf8("flop flip flop")
+        sink.writeString("flop flip flop")
         sink.emit()
         assertEquals(10, source.indexOf("flop".encodeToByteString(), 1))
-        source.readUtf8() // Clear stream
+        source.readString() // Clear stream
 
         // Make sure we backtrack and resume searching after partial match.
-        sink.writeUtf8("hi hi hi hi hey")
+        sink.writeString("hi hi hi hi hey")
         sink.emit()
         assertEquals(6, source.indexOf("hi hi hey".encodeToByteString(), 1))
     }
@@ -1671,7 +1671,7 @@ abstract class AbstractBufferedSourceTest internal constructor(
     fun indexOfEmptyByteString() {
         assertEquals(0, source.indexOf(ByteString()))
 
-        sink.writeUtf8("blablabla")
+        sink.writeString("blablabla")
         sink.emit()
         assertEquals(0, source.indexOf(ByteString()))
     }
@@ -1689,8 +1689,8 @@ abstract class AbstractBufferedSourceTest internal constructor(
      */
     @Test
     fun indexOfByteStringAcrossSegmentBoundaries() {
-        sink.writeUtf8("a".repeat(Segment.SIZE * 2 - 3))
-        sink.writeUtf8("bcdefg")
+        sink.writeString("a".repeat(Segment.SIZE * 2 - 3))
+        sink.writeString("bcdefg")
         sink.emit()
         assertEquals((Segment.SIZE * 2 - 4).toLong(), source.indexOf("ab".encodeToByteString()))
         assertEquals((Segment.SIZE * 2 - 4).toLong(), source.indexOf("abc".encodeToByteString()))

--- a/core/common/test/CommonBufferTest.kt
+++ b/core/common/test/CommonBufferTest.kt
@@ -37,16 +37,16 @@ class CommonBufferTest {
     @Test
     fun readAndWriteUtf8() {
         val buffer = Buffer()
-        buffer.writeUtf8("ab")
+        buffer.writeString("ab")
         assertEquals(2, buffer.size)
-        buffer.writeUtf8("cdef")
+        buffer.writeString("cdef")
         assertEquals(6, buffer.size)
-        assertEquals("abcd", buffer.readUtf8(4))
+        assertEquals("abcd", buffer.readString(4))
         assertEquals(2, buffer.size)
-        assertEquals("ef", buffer.readUtf8(2))
+        assertEquals("ef", buffer.readString(2))
         assertEquals(0, buffer.size)
         assertFailsWith<EOFException> {
-            buffer.readUtf8(1)
+            buffer.readString(1)
         }
     }
 
@@ -56,12 +56,12 @@ class CommonBufferTest {
 
         assertEquals(
             "Buffer(size=10 hex=610d0a620a630d645c65)",
-            Buffer().also { it.writeUtf8("a\r\nb\nc\rd\\e") }.toString()
+            Buffer().also { it.writeString("a\r\nb\nc\rd\\e") }.toString()
         )
 
         assertEquals(
             "Buffer(size=11 hex=547972616e6e6f73617572)",
-            Buffer().also { it.writeUtf8("Tyrannosaur") }.toString()
+            Buffer().also { it.writeString("Tyrannosaur") }.toString()
         )
 
         assertEquals(
@@ -85,19 +85,19 @@ class CommonBufferTest {
     @Test
     fun multipleSegmentBuffers() {
         val buffer = Buffer()
-        buffer.writeUtf8('a'.repeat(1000))
-        buffer.writeUtf8('b'.repeat(2500))
-        buffer.writeUtf8('c'.repeat(5000))
-        buffer.writeUtf8('d'.repeat(10000))
-        buffer.writeUtf8('e'.repeat(25000))
-        buffer.writeUtf8('f'.repeat(50000))
+        buffer.writeString('a'.repeat(1000))
+        buffer.writeString('b'.repeat(2500))
+        buffer.writeString('c'.repeat(5000))
+        buffer.writeString('d'.repeat(10000))
+        buffer.writeString('e'.repeat(25000))
+        buffer.writeString('f'.repeat(50000))
 
-        assertEquals('a'.repeat(999), buffer.readUtf8(999)) // a...a
-        assertEquals("a" + 'b'.repeat(2500) + "c", buffer.readUtf8(2502)) // ab...bc
-        assertEquals('c'.repeat(4998), buffer.readUtf8(4998)) // c...c
-        assertEquals("c" + 'd'.repeat(10000) + "e", buffer.readUtf8(10002)) // cd...de
-        assertEquals('e'.repeat(24998), buffer.readUtf8(24998)) // e...e
-        assertEquals("e" + 'f'.repeat(50000), buffer.readUtf8(50001)) // ef...f
+        assertEquals('a'.repeat(999), buffer.readString(999)) // a...a
+        assertEquals("a" + 'b'.repeat(2500) + "c", buffer.readString(2502)) // ab...bc
+        assertEquals('c'.repeat(4998), buffer.readString(4998)) // c...c
+        assertEquals("c" + 'd'.repeat(10000) + "e", buffer.readString(10002)) // cd...de
+        assertEquals('e'.repeat(24998), buffer.readString(24998)) // e...e
+        assertEquals("e" + 'f'.repeat(50000), buffer.readString(50001)) // ef...f
         assertEquals(0, buffer.size)
     }
 
@@ -159,12 +159,12 @@ class CommonBufferTest {
         val buffer = Buffer()
         for (s in contents) {
             val source = Buffer()
-            source.writeUtf8(s)
+            source.writeString(s)
             buffer.transferFrom(source)
             expected.append(s)
         }
         val segmentSizes = segmentSizes(buffer)
-        assertEquals(expected.toString(), buffer.readUtf8(expected.length.toLong()))
+        assertEquals(expected.toString(), buffer.readString(expected.length.toLong()))
         return segmentSizes
     }
 
@@ -174,10 +174,10 @@ class CommonBufferTest {
         val writeSize = Segment.SIZE / 2 + 1
 
         val sink = Buffer()
-        sink.writeUtf8('b'.repeat(Segment.SIZE - 10))
+        sink.writeString('b'.repeat(Segment.SIZE - 10))
 
         val source = Buffer()
-        source.writeUtf8('a'.repeat(Segment.SIZE * 2))
+        source.writeString('a'.repeat(Segment.SIZE * 2))
         sink.write(source, writeSize.toLong())
 
         assertEquals(listOf(Segment.SIZE - 10, writeSize), segmentSizes(sink))
@@ -190,10 +190,10 @@ class CommonBufferTest {
         val writeSize = Segment.SIZE / 2 - 1
 
         val sink = Buffer()
-        sink.writeUtf8('b'.repeat(Segment.SIZE - 10))
+        sink.writeString('b'.repeat(Segment.SIZE - 10))
 
         val source = Buffer()
-        source.writeUtf8('a'.repeat(Segment.SIZE * 2))
+        source.writeString('a'.repeat(Segment.SIZE * 2))
         sink.write(source, writeSize.toLong())
 
         assertEquals(listOf(Segment.SIZE - 10, writeSize), segmentSizes(sink))
@@ -203,10 +203,10 @@ class CommonBufferTest {
     @Test
     fun writePrefixDoesntSplit() {
         val sink = Buffer()
-        sink.writeUtf8('b'.repeat(10))
+        sink.writeString('b'.repeat(10))
 
         val source = Buffer()
-        source.writeUtf8('a'.repeat(Segment.SIZE * 2))
+        source.writeString('a'.repeat(Segment.SIZE * 2))
         sink.write(source, 20)
 
         assertEquals(listOf(30), segmentSizes(sink))
@@ -218,11 +218,11 @@ class CommonBufferTest {
     @Test
     fun writePrefixDoesntSplitButRequiresCompact() {
         val sink = Buffer()
-        sink.writeUtf8('b'.repeat(Segment.SIZE - 10)) // limit = size - 10
-        sink.readUtf8((Segment.SIZE - 20).toLong()) // pos = size = 20
+        sink.writeString('b'.repeat(Segment.SIZE - 10)) // limit = size - 10
+        sink.readString((Segment.SIZE - 20).toLong()) // pos = size = 20
 
         val source = Buffer()
-        source.writeUtf8('a'.repeat(Segment.SIZE * 2))
+        source.writeString('a'.repeat(Segment.SIZE * 2))
         sink.write(source, 20)
 
         assertEquals(listOf(30), segmentSizes(sink))
@@ -242,39 +242,39 @@ class CommonBufferTest {
     @Test
     fun moveAllRequestedBytesWithRead() {
         val sink = Buffer()
-        sink.writeUtf8('a'.repeat(10))
+        sink.writeString('a'.repeat(10))
 
         val source = Buffer()
-        source.writeUtf8('b'.repeat(15))
+        source.writeString('b'.repeat(15))
 
         assertEquals(10, source.readAtMostTo(sink, 10))
         assertEquals(20, sink.size)
         assertEquals(5, source.size)
-        assertEquals('a'.repeat(10) + 'b'.repeat(10), sink.readUtf8(20))
+        assertEquals('a'.repeat(10) + 'b'.repeat(10), sink.readString(20))
     }
 
     @Test
     fun moveFewerThanRequestedBytesWithRead() {
         val sink = Buffer()
-        sink.writeUtf8('a'.repeat(10))
+        sink.writeString('a'.repeat(10))
 
         val source = Buffer()
-        source.writeUtf8('b'.repeat(20))
+        source.writeString('b'.repeat(20))
 
         assertEquals(20, source.readAtMostTo(sink, 25))
         assertEquals(30, sink.size)
         assertEquals(0, source.size)
-        assertEquals('a'.repeat(10) + 'b'.repeat(20), sink.readUtf8(30))
+        assertEquals('a'.repeat(10) + 'b'.repeat(20), sink.readString(30))
     }
 
     @Test
     fun indexOfWithOffset() {
         val buffer = Buffer()
         val halfSegment = Segment.SIZE / 2
-        buffer.writeUtf8('a'.repeat(halfSegment))
-        buffer.writeUtf8('b'.repeat(halfSegment))
-        buffer.writeUtf8('c'.repeat(halfSegment))
-        buffer.writeUtf8('d'.repeat(halfSegment))
+        buffer.writeString('a'.repeat(halfSegment))
+        buffer.writeString('b'.repeat(halfSegment))
+        buffer.writeString('c'.repeat(halfSegment))
+        buffer.writeString('d'.repeat(halfSegment))
         assertEquals(0, buffer.indexOf('a'.code.toByte(), 0))
         assertEquals((halfSegment - 1).toLong(), buffer.indexOf('a'.code.toByte(), (halfSegment - 1).toLong()))
         assertEquals(halfSegment.toLong(), buffer.indexOf('b'.code.toByte(), (halfSegment - 1).toLong()))
@@ -288,9 +288,9 @@ class CommonBufferTest {
     @Test
     fun byteAt() {
         val buffer = Buffer()
-        buffer.writeUtf8("a")
-        buffer.writeUtf8('b'.repeat(Segment.SIZE))
-        buffer.writeUtf8("c")
+        buffer.writeString("a")
+        buffer.writeString('b'.repeat(Segment.SIZE))
+        buffer.writeString("c")
         assertEquals('a'.code.toLong(), buffer[0].toLong())
         assertEquals('a'.code.toLong(), buffer[0].toLong()) // getByte doesn't mutate!
         assertEquals('c'.code.toLong(), buffer[buffer.size - 1].toLong())
@@ -318,21 +318,21 @@ class CommonBufferTest {
     fun writePrefixToEmptyBuffer() {
         val sink = Buffer()
         val source = Buffer()
-        source.writeUtf8("abcd")
+        source.writeString("abcd")
         sink.write(source, 2)
-        assertEquals("ab", sink.readUtf8(2))
+        assertEquals("ab", sink.readString(2))
     }
 
     // Buffer don't override equals and hashCode
     @Test
     fun equalsAndHashCode() {
-        val a = Buffer().also { it.writeUtf8("dog") }
+        val a = Buffer().also { it.writeString("dog") }
         assertEquals(a, a)
 
-        val b = Buffer().also { it.writeUtf8("hotdog") }
+        val b = Buffer().also { it.writeString("hotdog") }
         assertTrue(a != b)
 
-        b.readUtf8(3) // Leaves b containing 'dog'.
+        b.readString(3) // Leaves b containing 'dog'.
         assertTrue(a != b)
     }
 
@@ -343,14 +343,14 @@ class CommonBufferTest {
     @Test
     fun readAllWritesAllSegmentsAtOnce() {
         val write1 = Buffer()
-        write1.writeUtf8(
+        write1.writeString(
             'a'.repeat(Segment.SIZE) +
                     'b'.repeat(Segment.SIZE) +
                     'c'.repeat(Segment.SIZE)
         )
 
         val source = Buffer()
-        source.writeUtf8(
+        source.writeString(
             'a'.repeat(Segment.SIZE) +
                     'b'.repeat(Segment.SIZE) +
                     'c'.repeat(Segment.SIZE)
@@ -365,60 +365,60 @@ class CommonBufferTest {
 
     @Test
     fun writeAllMultipleSegments() {
-        val source = Buffer().also { it.writeUtf8('a'.repeat(Segment.SIZE * 3)) }
+        val source = Buffer().also { it.writeString('a'.repeat(Segment.SIZE * 3)) }
         val sink = Buffer()
 
         assertEquals((Segment.SIZE * 3).toLong(), sink.transferFrom(source))
         assertEquals(0, source.size)
-        assertEquals('a'.repeat(Segment.SIZE * 3), sink.readUtf8())
+        assertEquals('a'.repeat(Segment.SIZE * 3), sink.readString())
     }
 
     @Test
     fun copyTo() {
         val source = Buffer()
-        source.writeUtf8("party")
+        source.writeString("party")
 
         val target = Buffer()
         source.copyTo(target, startIndex = 1, endIndex = 4)
 
-        assertEquals("art", target.readUtf8())
-        assertEquals("party", source.readUtf8())
+        assertEquals("art", target.readString())
+        assertEquals("party", source.readString())
     }
 
     @Test
     fun copyToAll() {
         val source = Buffer()
-        source.writeUtf8("hello")
+        source.writeString("hello")
 
         val target = Buffer()
         source.copyTo(target)
 
-        assertEquals("hello", source.readUtf8())
-        assertEquals("hello", target.readUtf8())
+        assertEquals("hello", source.readString())
+        assertEquals("hello", target.readString())
     }
 
     @Test
     fun copyToWithOnlyStartIndex() {
         val source = Buffer()
-        source.writeUtf8("hello")
+        source.writeString("hello")
 
         val target = Buffer()
         source.copyTo(target, startIndex = 1)
 
-        assertEquals("hello", source.readUtf8())
-        assertEquals("ello", target.readUtf8())
+        assertEquals("hello", source.readString())
+        assertEquals("ello", target.readString())
     }
 
     @Test
     fun copyToWithOnlyEndIndex() {
         val source = Buffer()
-        source.writeUtf8("hello")
+        source.writeString("hello")
 
         val target = Buffer()
         source.copyTo(target, endIndex = 1)
 
-        assertEquals("hello", source.readUtf8())
-        assertEquals("h", target.readUtf8())
+        assertEquals("hello", source.readString())
+        assertEquals("h", target.readString())
     }
 
     @Test
@@ -429,18 +429,18 @@ class CommonBufferTest {
         val ds = 'd'.repeat(Segment.SIZE)
 
         val source = Buffer()
-        source.writeUtf8(aStr)
-        source.writeUtf8(bs)
-        source.writeUtf8(cs)
+        source.writeString(aStr)
+        source.writeString(bs)
+        source.writeString(cs)
 
         val target = Buffer()
-        target.writeUtf8(ds)
+        target.writeString(ds)
 
         source.copyTo(
             target, startIndex = aStr.length.toLong(),
             endIndex = aStr.length.toLong() + (bs.length + cs.length).toLong()
         )
-        assertEquals(ds + bs + cs, target.readUtf8())
+        assertEquals(ds + bs + cs, target.readString())
     }
 
     @Test
@@ -451,18 +451,18 @@ class CommonBufferTest {
         val ds = 'd'.repeat(Segment.SIZE + 8)
 
         val source = Buffer()
-        source.writeUtf8(aStr)
-        source.writeUtf8(bs)
-        source.writeUtf8(cs)
+        source.writeString(aStr)
+        source.writeString(bs)
+        source.writeString(cs)
 
         val target = Buffer()
-        target.writeUtf8(ds)
+        target.writeString(ds)
 
         source.copyTo(
             target, startIndex = aStr.length.toLong(),
             endIndex = aStr.length.toLong() + (bs.length + cs.length).toLong()
         )
-        assertEquals(ds + bs + cs, target.readUtf8())
+        assertEquals(ds + bs + cs, target.readString())
     }
 
     @Test
@@ -471,29 +471,29 @@ class CommonBufferTest {
         val bs = 'b'.repeat(Segment.SIZE)
 
         val source = Buffer()
-        source.writeUtf8(aStr)
-        source.writeUtf8(bs)
+        source.writeString(aStr)
+        source.writeString(bs)
 
         source.copyTo(source, startIndex = 0, endIndex = source.size)
-        assertEquals(aStr + bs + aStr + bs, source.readUtf8())
+        assertEquals(aStr + bs + aStr + bs, source.readString())
     }
 
     @Test
     fun copyToEmptySource() {
         val source = Buffer()
-        val target = Buffer().also { it.writeUtf8("aaa") }
+        val target = Buffer().also { it.writeString("aaa") }
         source.copyTo(target, startIndex = 0L, endIndex = 0L)
-        assertEquals("", source.readUtf8())
-        assertEquals("aaa", target.readUtf8())
+        assertEquals("", source.readString())
+        assertEquals("aaa", target.readString())
     }
 
     @Test
     fun copyToEmptyTarget() {
-        val source = Buffer().also { it.writeUtf8("aaa") }
+        val source = Buffer().also { it.writeString("aaa") }
         val target = Buffer()
         source.copyTo(target, startIndex = 0L, endIndex = 3L)
-        assertEquals("aaa", source.readUtf8())
-        assertEquals("aaa", target.readUtf8())
+        assertEquals("aaa", source.readString())
+        assertEquals("aaa", target.readString())
     }
 
     @Test
@@ -505,14 +505,14 @@ class CommonBufferTest {
     @Test
     fun completeSegmentByteCountOnBufferWithFullSegments() {
         val buffer = Buffer()
-        buffer.writeUtf8("a".repeat(Segment.SIZE * 4))
+        buffer.writeString("a".repeat(Segment.SIZE * 4))
         assertEquals((Segment.SIZE * 4).toLong(), buffer.completeSegmentByteCount())
     }
 
     @Test
     fun completeSegmentByteCountOnBufferWithIncompleteTailSegment() {
         val buffer = Buffer()
-        buffer.writeUtf8("a".repeat(Segment.SIZE * 4 - 10))
+        buffer.writeString("a".repeat(Segment.SIZE * 4 - 10))
         assertEquals((Segment.SIZE * 3).toLong(), buffer.completeSegmentByteCount())
     }
 
@@ -520,53 +520,53 @@ class CommonBufferTest {
     fun cloneDoesNotObserveWritesToOriginal() {
         val original = Buffer()
         val clone: Buffer = original.copy()
-        original.writeUtf8("abc")
+        original.writeString("abc")
         assertEquals(0, clone.size)
     }
 
     @Test
     fun cloneDoesNotObserveReadsFromOriginal() {
         val original = Buffer()
-        original.writeUtf8("abc")
+        original.writeString("abc")
         val clone: Buffer = original.copy()
-        assertEquals("abc", original.readUtf8(3))
+        assertEquals("abc", original.readString(3))
         assertEquals(3, clone.size)
-        assertEquals("ab", clone.readUtf8(2))
+        assertEquals("ab", clone.readString(2))
     }
 
     @Test
     fun originalDoesNotObserveWritesToClone() {
         val original = Buffer()
         val clone: Buffer = original.copy()
-        clone.writeUtf8("abc")
+        clone.writeString("abc")
         assertEquals(0, original.size)
     }
 
     @Test
     fun originalDoesNotObserveReadsFromClone() {
         val original = Buffer()
-        original.writeUtf8("abc")
+        original.writeString("abc")
         val clone: Buffer = original.copy()
-        assertEquals("abc", clone.readUtf8(3))
+        assertEquals("abc", clone.readString(3))
         assertEquals(3, original.size)
-        assertEquals("ab", original.readUtf8(2))
+        assertEquals("ab", original.readString(2))
     }
 
     @Test
     fun cloneMultipleSegments() {
         val original = Buffer()
-        original.writeUtf8("a".repeat(SEGMENT_SIZE * 3))
+        original.writeString("a".repeat(SEGMENT_SIZE * 3))
         val clone: Buffer = original.copy()
-        original.writeUtf8("b".repeat(SEGMENT_SIZE * 3))
-        clone.writeUtf8("c".repeat(SEGMENT_SIZE * 3))
+        original.writeString("b".repeat(SEGMENT_SIZE * 3))
+        clone.writeString("c".repeat(SEGMENT_SIZE * 3))
 
         assertEquals(
             "a".repeat(SEGMENT_SIZE * 3) + "b".repeat(SEGMENT_SIZE * 3),
-            original.readUtf8((SEGMENT_SIZE * 6).toLong())
+            original.readString((SEGMENT_SIZE * 6).toLong())
         )
         assertEquals(
             "a".repeat(SEGMENT_SIZE * 3) + "c".repeat(SEGMENT_SIZE * 3),
-            clone.readUtf8((SEGMENT_SIZE * 6).toLong())
+            clone.readString((SEGMENT_SIZE * 6).toLong())
         )
     }
 
@@ -596,7 +596,7 @@ class CommonBufferTest {
     fun snapshot() {
         val buffer = Buffer()
         assertEquals(ByteString(), buffer.snapshot())
-        buffer.writeUtf8("hello")
+        buffer.writeString("hello")
         assertEquals("hello".encodeToByteString(), buffer.snapshot())
         buffer.clear()
         assertEquals(ByteString(), buffer.snapshot())

--- a/core/common/test/CommonPlatformTest.kt
+++ b/core/common/test/CommonPlatformTest.kt
@@ -27,9 +27,9 @@ import kotlin.test.assertEquals
 class CommonPlatformTest {
     @Test
     fun sourceBuffer() {
-        val source = Buffer().also { it.writeUtf8("a") }
+        val source = Buffer().also { it.writeString("a") }
         val buffered = (source as RawSource).buffered()
-        assertEquals(buffered.readUtf8(), "a")
+        assertEquals(buffered.readString(), "a")
         assertEquals(source.size, 0L)
     }
 
@@ -37,7 +37,7 @@ class CommonPlatformTest {
     fun sinkBuffer() {
         val sink = Buffer()
         val buffered = (sink as RawSink).buffered()
-        buffered.writeUtf8("a")
+        buffered.writeString("a")
         assertEquals(sink.size, 0L)
         buffered.flush()
         assertEquals(sink.size, 1L)
@@ -45,6 +45,6 @@ class CommonPlatformTest {
 
     @Test
     fun discardingSinkTest() {
-        discardingSink().write(Buffer().also { it.writeUtf8("a") }, 1L)
+        discardingSink().write(Buffer().also { it.writeString("a") }, 1L)
     }
 }

--- a/core/common/test/CommonRealSinkTest.kt
+++ b/core/common/test/CommonRealSinkTest.kt
@@ -35,7 +35,7 @@ class CommonRealSinkTest {
     fun bufferedSinkEmitsTailWhenItIsComplete() {
         val sink = Buffer()
         val bufferedSink = (sink as RawSink).buffered()
-        bufferedSink.writeUtf8("a".repeat(Segment.SIZE - 1))
+        bufferedSink.writeString("a".repeat(Segment.SIZE - 1))
         assertEquals(0, sink.size)
         bufferedSink.writeByte(0)
         assertEquals(Segment.SIZE.toLong(), sink.size)
@@ -46,7 +46,7 @@ class CommonRealSinkTest {
     fun bufferedSinkEmitMultipleSegments() {
         val sink = Buffer()
         val bufferedSink = (sink as RawSink).buffered()
-        bufferedSink.writeUtf8("a".repeat(Segment.SIZE * 4 - 1))
+        bufferedSink.writeString("a".repeat(Segment.SIZE * 4 - 1))
         assertEquals(Segment.SIZE.toLong() * 3L, sink.size)
         assertEquals(Segment.SIZE.toLong() - 1L, bufferedSink.buffer.size)
     }
@@ -66,7 +66,7 @@ class CommonRealSinkTest {
     fun bytesEmittedToSinkWithFlush() {
         val sink = Buffer()
         val bufferedSink = (sink as RawSink).buffered()
-        bufferedSink.writeUtf8("abc")
+        bufferedSink.writeString("abc")
         bufferedSink.flush()
         assertEquals(3, sink.size)
     }
@@ -75,7 +75,7 @@ class CommonRealSinkTest {
     fun bytesNotEmittedToSinkWithoutFlush() {
         val sink = Buffer()
         val bufferedSink = (sink as RawSink).buffered()
-        bufferedSink.writeUtf8("abc")
+        bufferedSink.writeString("abc")
         assertEquals(0, sink.size)
     }
 
@@ -83,7 +83,7 @@ class CommonRealSinkTest {
     fun bytesEmittedToSinkWithEmit() {
         val sink = Buffer()
         val bufferedSink = (sink as RawSink).buffered()
-        bufferedSink.writeUtf8("abc")
+        bufferedSink.writeString("abc")
         bufferedSink.emit()
         assertEquals(3, sink.size)
     }
@@ -92,7 +92,7 @@ class CommonRealSinkTest {
     fun completeSegmentsEmitted() {
         val sink = Buffer()
         val bufferedSink = (sink as RawSink).buffered()
-        bufferedSink.writeUtf8("a".repeat(Segment.SIZE * 3))
+        bufferedSink.writeString("a".repeat(Segment.SIZE * 3))
         assertEquals(Segment.SIZE.toLong() * 3L, sink.size)
     }
 
@@ -100,7 +100,7 @@ class CommonRealSinkTest {
     fun incompleteSegmentsNotEmitted() {
         val sink = Buffer()
         val bufferedSink = (sink as RawSink).buffered()
-        bufferedSink.writeUtf8("a".repeat(Segment.SIZE * 3 - 1))
+        bufferedSink.writeString("a".repeat(Segment.SIZE * 3 - 1))
         assertEquals(Segment.SIZE.toLong() * 2L, sink.size)
     }
 
@@ -164,11 +164,11 @@ class CommonRealSinkTest {
         val mockSink = MockSink()
         val bufferedSink = mockSink.buffered()
 
-        bufferedSink.buffer.writeUtf8("abc")
-        assertEquals(3, bufferedSink.transferFrom(Buffer().also { it.writeUtf8("def") }))
+        bufferedSink.buffer.writeString("abc")
+        assertEquals(3, bufferedSink.transferFrom(Buffer().also { it.writeString("def") }))
 
         assertEquals(6, bufferedSink.buffer.size)
-        assertEquals("abcdef", bufferedSink.buffer.readUtf8(6))
+        assertEquals("abcdef", bufferedSink.buffer.readString(6))
         mockSink.assertLog() // No writes.
     }
 
@@ -184,12 +184,12 @@ class CommonRealSinkTest {
 
     @Test
     fun writeAllWritesOneSegmentAtATime() {
-        val write1 = Buffer().also { it.writeUtf8("a".repeat(Segment.SIZE)) }
-        val write2 = Buffer().also { it.writeUtf8("b".repeat(Segment.SIZE)) }
-        val write3 = Buffer().also { it.writeUtf8("c".repeat(Segment.SIZE)) }
+        val write1 = Buffer().also { it.writeString("a".repeat(Segment.SIZE)) }
+        val write2 = Buffer().also { it.writeString("b".repeat(Segment.SIZE)) }
+        val write3 = Buffer().also { it.writeString("c".repeat(Segment.SIZE)) }
 
         val source = Buffer()
-        source.writeUtf8(
+        source.writeString(
             "${"a".repeat(Segment.SIZE)}${"b".repeat(Segment.SIZE)}${"c".repeat(Segment.SIZE)}"
         )
 

--- a/core/common/test/CommonRealSourceTest.kt
+++ b/core/common/test/CommonRealSourceTest.kt
@@ -33,7 +33,7 @@ import kotlin.test.assertFailsWith
 class CommonRealSourceTest {
     @Test
     fun indexOfStopsReadingAtLimit() {
-        val buffer = Buffer().also { it.writeUtf8("abcdef") }
+        val buffer = Buffer().also { it.writeString("abcdef") }
         val bufferedSource = (
                 object : RawSource by buffer {
                     override fun readAtMostTo(sink: Buffer, byteCount: Long): Long {
@@ -50,10 +50,10 @@ class CommonRealSourceTest {
     @Test
     fun requireTracksBufferFirst() {
         val source = Buffer()
-        source.writeUtf8("bb")
+        source.writeString("bb")
 
         val bufferedSource = (source as RawSource).buffered()
-        bufferedSource.buffer.writeUtf8("aa")
+        bufferedSource.buffer.writeString("aa")
 
         bufferedSource.require(2)
         assertEquals(2, bufferedSource.buffer.size)
@@ -63,19 +63,19 @@ class CommonRealSourceTest {
     @Test
     fun requireIncludesBufferBytes() {
         val source = Buffer()
-        source.writeUtf8("b")
+        source.writeString("b")
 
         val bufferedSource = (source as RawSource).buffered()
-        bufferedSource.buffer.writeUtf8("a")
+        bufferedSource.buffer.writeString("a")
 
         bufferedSource.require(2)
-        assertEquals("ab", bufferedSource.buffer.readUtf8(2))
+        assertEquals("ab", bufferedSource.buffer.readString(2))
     }
 
     @Test
     fun requireInsufficientData() {
         val source = Buffer()
-        source.writeUtf8("a")
+        source.writeString("a")
 
         val bufferedSource = (source as RawSource).buffered()
 
@@ -87,8 +87,8 @@ class CommonRealSourceTest {
     @Test
     fun requireReadsOneSegmentAtATime() {
         val source = Buffer()
-        source.writeUtf8("a".repeat(Segment.SIZE))
-        source.writeUtf8("b".repeat(Segment.SIZE))
+        source.writeString("a".repeat(Segment.SIZE))
+        source.writeString("b".repeat(Segment.SIZE))
 
         val bufferedSource = (source as RawSource).buffered()
 
@@ -100,8 +100,8 @@ class CommonRealSourceTest {
     @Test
     fun skipReadsOneSegmentAtATime() {
         val source = Buffer()
-        source.writeUtf8("a".repeat(Segment.SIZE))
-        source.writeUtf8("b".repeat(Segment.SIZE))
+        source.writeString("a".repeat(Segment.SIZE))
+        source.writeString("b".repeat(Segment.SIZE))
         val bufferedSource = (source as RawSource).buffered()
         bufferedSource.skip(2)
         assertEquals(Segment.SIZE.toLong(), source.size)
@@ -111,10 +111,10 @@ class CommonRealSourceTest {
     @Test
     fun skipTracksBufferFirst() {
         val source = Buffer()
-        source.writeUtf8("bb")
+        source.writeString("bb")
 
         val bufferedSource = (source as RawSource).buffered()
-        bufferedSource.buffer.writeUtf8("aa")
+        bufferedSource.buffer.writeString("aa")
 
         bufferedSource.skip(2)
         assertEquals(0, bufferedSource.buffer.size)
@@ -143,12 +143,12 @@ class CommonRealSourceTest {
      */
     @Test
     fun transferToReadsOneSegmentAtATime() {
-        val write1 = Buffer().also { it.writeUtf8("a".repeat(Segment.SIZE)) }
-        val write2 = Buffer().also { it.writeUtf8("b".repeat(Segment.SIZE)) }
-        val write3 = Buffer().also { it.writeUtf8("c".repeat(Segment.SIZE)) }
+        val write1 = Buffer().also { it.writeString("a".repeat(Segment.SIZE)) }
+        val write2 = Buffer().also { it.writeString("b".repeat(Segment.SIZE)) }
+        val write3 = Buffer().also { it.writeString("c".repeat(Segment.SIZE)) }
 
         val source = Buffer()
-        source.writeUtf8(
+        source.writeString(
             "${"a".repeat(Segment.SIZE)}${"b".repeat(Segment.SIZE)}${"c".repeat(Segment.SIZE)}"
         )
 

--- a/core/common/test/Utf8Test.kt
+++ b/core/common/test/Utf8Test.kt
@@ -332,7 +332,7 @@ class Utf8Test {
     }
 
     private fun Buffer.assertUtf8StringEncoded(expectedHex: String, string: String) {
-        writeUtf8(string)
+        writeString(string)
         assertArrayEquals(expectedHex.decodeHex(), readByteArray())
     }
 

--- a/core/common/test/files/SmokeFileTest.kt
+++ b/core/common/test/files/SmokeFileTest.kt
@@ -30,11 +30,11 @@ class SmokeFileTest {
         val path = Path(tempFile!!)
 
         path.sink().use {
-            it.writeUtf8("example")
+            it.writeString("example")
         }
 
         path.source().use {
-            assertEquals("example", it.readUtf8Line())
+            assertEquals("example", it.readLine())
         }
     }
 

--- a/core/jvm/src/SinkExtJvm.kt
+++ b/core/jvm/src/SinkExtJvm.kt
@@ -41,7 +41,7 @@ import java.nio.charset.Charset
  */
 public fun Sink.writeString(string: String, charset: Charset, startIndex: Int = 0, endIndex: Int = string.length) {
     checkBounds(string.length, startIndex, endIndex)
-    if (charset == Charsets.UTF_8) return writeUtf8(string, startIndex, endIndex)
+    if (charset == Charsets.UTF_8) return writeString(string, startIndex, endIndex)
     val data = string.substring(startIndex, endIndex).toByteArray(charset)
     write(data, 0, data.size)
 }

--- a/core/jvm/test/AbstractSinkTestJVM.kt
+++ b/core/jvm/test/AbstractSinkTestJVM.kt
@@ -45,7 +45,7 @@ abstract class AbstractSinkTestJVM internal constructor(factory: SinkFactory) {
         out.write("b".repeat(9998).toByteArray(UTF_8))
         out.write('c'.code)
         out.flush()
-        assertEquals(("a" + "b".repeat(9998)) + "c", data.readUtf8())
+        assertEquals(("a" + "b".repeat(9998)) + "c", data.readString())
     }
 
     @Test
@@ -90,7 +90,7 @@ abstract class AbstractSinkTestJVM internal constructor(factory: SinkFactory) {
         assertEquals(expected.length, nioByteBuffer.position())
         assertEquals(expected.length, nioByteBuffer.limit())
         sink.flush()
-        assertEquals(expected, data.readUtf8())
+        assertEquals(expected, data.readString())
     }
 
     @Test
@@ -104,7 +104,7 @@ abstract class AbstractSinkTestJVM internal constructor(factory: SinkFactory) {
         assertEquals(expected.length, nioByteBuffer.position())
         assertEquals(expected.length, nioByteBuffer.limit())
         sink.flush()
-        assertEquals(expected, data.readUtf8())
+        assertEquals(expected, data.readString())
     }
 
     @Test

--- a/core/jvm/test/AbstractSourceTestJVM.kt
+++ b/core/jvm/test/AbstractSourceTestJVM.kt
@@ -50,7 +50,7 @@ abstract class AbstractSourceTestJVM(private val factory: SourceFactory) {
 
     @Test
     fun inputStream() {
-        sink.writeUtf8("abc")
+        sink.writeString("abc")
         sink.emit()
         val input: InputStream = source.asInputStream()
         val bytes = byteArrayOf('z'.code.toByte(), 'z'.code.toByte(), 'z'.code.toByte())
@@ -73,7 +73,7 @@ abstract class AbstractSourceTestJVM(private val factory: SourceFactory) {
 
     @Test
     fun inputStreamOffsetCount() {
-        sink.writeUtf8("abcde")
+        sink.writeString("abcde")
         sink.emit()
         val input: InputStream = source.asInputStream()
         val bytes =
@@ -90,12 +90,12 @@ abstract class AbstractSourceTestJVM(private val factory: SourceFactory) {
 
     @Test
     fun inputStreamSkip() {
-        sink.writeUtf8("abcde")
+        sink.writeString("abcde")
         sink.emit()
         val input: InputStream = source.asInputStream()
         assertEquals(4, input.skip(4))
         assertEquals('e'.code, input.read())
-        sink.writeUtf8("abcde")
+        sink.writeString("abcde")
         sink.emit()
         assertEquals(5, input.skip(10)) // Try to skip too much.
         assertEquals(0, input.skip(1)) // Try to skip when exhausted.
@@ -103,7 +103,7 @@ abstract class AbstractSourceTestJVM(private val factory: SourceFactory) {
 
     @Test
     fun inputStreamCharByChar() {
-        sink.writeUtf8("abc")
+        sink.writeString("abc")
         sink.emit()
         val input: InputStream = source.asInputStream()
         assertEquals('a'.code, input.read())
@@ -114,7 +114,7 @@ abstract class AbstractSourceTestJVM(private val factory: SourceFactory) {
 
     @Test
     fun inputStreamBounds() {
-        sink.writeUtf8("a".repeat(100))
+        sink.writeString("a".repeat(100))
         sink.emit()
         val input: InputStream = source.asInputStream()
         assertFailsWith<IllegalArgumentException> {
@@ -196,7 +196,7 @@ abstract class AbstractSourceTestJVM(private val factory: SourceFactory) {
     @Test
     fun readNioBuffer() {
         val expected = if (factory.isOneByteAtATime) "a" else "abcdefg"
-        sink.writeUtf8("abcdefg")
+        sink.writeString("abcdefg")
         sink.emit()
         val nioByteBuffer: ByteBuffer = ByteBuffer.allocate(1024)
         val byteCount: Int = source.readAtMostTo(nioByteBuffer)
@@ -213,7 +213,7 @@ abstract class AbstractSourceTestJVM(private val factory: SourceFactory) {
     @Test
     fun readLargeNioBufferOnlyReadsOneSegment() {
         val expected: String = if (factory.isOneByteAtATime) "a" else "a".repeat(SEGMENT_SIZE)
-        sink.writeUtf8("a".repeat(SEGMENT_SIZE * 4))
+        sink.writeString("a".repeat(SEGMENT_SIZE * 4))
         sink.emit()
         val nioByteBuffer: ByteBuffer = ByteBuffer.allocate(SEGMENT_SIZE * 3)
         val byteCount: Int = source.readAtMostTo(nioByteBuffer)
@@ -259,6 +259,6 @@ abstract class AbstractSourceTestJVM(private val factory: SourceFactory) {
         assertFailsWith<EOFException> {
             source.readString(4, Charsets.US_ASCII)
         }
-        assertEquals("abc", source.readUtf8()) // The read shouldn't consume any data.
+        assertEquals("abc", source.readString()) // The read shouldn't consume any data.
     }
 }

--- a/core/jvm/test/BufferTest.kt
+++ b/core/jvm/test/BufferTest.kt
@@ -36,8 +36,8 @@ class BufferTest {
     @Test
     fun copyToSpanningSegments() {
         val source = Buffer()
-        source.writeUtf8("a".repeat(SEGMENT_SIZE * 2))
-        source.writeUtf8("b".repeat(SEGMENT_SIZE * 2))
+        source.writeString("a".repeat(SEGMENT_SIZE * 2))
+        source.writeString("b".repeat(SEGMENT_SIZE * 2))
         val out = ByteArrayOutputStream()
         source.copyTo(out, startIndex = 10L, endIndex = 10L + SEGMENT_SIZE * 3L)
         assertEquals(
@@ -46,49 +46,49 @@ class BufferTest {
         )
         assertEquals(
             "a".repeat(SEGMENT_SIZE * 2) + "b".repeat(SEGMENT_SIZE * 2),
-            source.readUtf8(SEGMENT_SIZE * 4L)
+            source.readString(SEGMENT_SIZE * 4L)
         )
     }
 
     @Test
     fun copyToSkippingSegments() {
         val source = Buffer()
-        source.writeUtf8("a".repeat(SEGMENT_SIZE * 2))
-        source.writeUtf8("b".repeat(SEGMENT_SIZE * 2))
+        source.writeString("a".repeat(SEGMENT_SIZE * 2))
+        source.writeString("b".repeat(SEGMENT_SIZE * 2))
         val out = ByteArrayOutputStream()
         source.copyTo(out, startIndex = SEGMENT_SIZE * 2 + 1L, endIndex = SEGMENT_SIZE * 2 + 4L)
         assertEquals("bbb", out.toString())
         assertEquals(
             "a".repeat(SEGMENT_SIZE * 2) + "b".repeat(SEGMENT_SIZE * 2),
-            source.readUtf8(SEGMENT_SIZE * 4L)
+            source.readString(SEGMENT_SIZE * 4L)
         )
     }
 
     @Test
     fun copyToStream() {
-        val buffer = Buffer().also { it.writeUtf8("hello, world!") }
+        val buffer = Buffer().also { it.writeString("hello, world!") }
         val out = ByteArrayOutputStream()
         buffer.copyTo(out)
         val outString = String(out.toByteArray(), UTF_8)
         assertEquals("hello, world!", outString)
-        assertEquals("hello, world!", buffer.readUtf8())
+        assertEquals("hello, world!", buffer.readString())
     }
 
     @Test
     fun writeToSpanningSegments() {
         val buffer = Buffer()
-        buffer.writeUtf8("a".repeat(SEGMENT_SIZE * 2))
-        buffer.writeUtf8("b".repeat(SEGMENT_SIZE * 2))
+        buffer.writeString("a".repeat(SEGMENT_SIZE * 2))
+        buffer.writeString("b".repeat(SEGMENT_SIZE * 2))
         val out = ByteArrayOutputStream()
         buffer.skip(10)
         buffer.readTo(out, SEGMENT_SIZE * 3L)
         assertEquals("a".repeat(SEGMENT_SIZE * 2 - 10) + "b".repeat(SEGMENT_SIZE + 10), out.toString())
-        assertEquals("b".repeat(SEGMENT_SIZE - 10), buffer.readUtf8(buffer.size))
+        assertEquals("b".repeat(SEGMENT_SIZE - 10), buffer.readString(buffer.size))
     }
 
     @Test
     fun writeToStream() {
-        val buffer = Buffer().also { it.writeUtf8("hello, world!") }
+        val buffer = Buffer().also { it.writeString("hello, world!") }
         val out = ByteArrayOutputStream()
         buffer.readTo(out)
         val outString = String(out.toByteArray(), UTF_8)
@@ -101,16 +101,16 @@ class BufferTest {
         val input: InputStream = ByteArrayInputStream("hello, world!".toByteArray(UTF_8))
         val buffer = Buffer()
         buffer.transferFrom(input)
-        val out = buffer.readUtf8()
+        val out = buffer.readString()
         assertEquals("hello, world!", out)
     }
 
     @Test
     fun readFromSpanningSegments() {
         val input: InputStream = ByteArrayInputStream("hello, world!".toByteArray(UTF_8))
-        val buffer = Buffer().also { it.writeUtf8("a".repeat(SEGMENT_SIZE - 10)) }
+        val buffer = Buffer().also { it.writeString("a".repeat(SEGMENT_SIZE - 10)) }
         buffer.transferFrom(input)
-        val out = buffer.readUtf8()
+        val out = buffer.readString()
         assertEquals("a".repeat(SEGMENT_SIZE - 10) + "hello, world!", out)
     }
 
@@ -119,7 +119,7 @@ class BufferTest {
         val input: InputStream = ByteArrayInputStream("hello, world!".toByteArray(UTF_8))
         val buffer = Buffer()
         buffer.write(input, 10)
-        val out = buffer.readUtf8()
+        val out = buffer.readString()
         assertEquals("hello, wor", out)
     }
 
@@ -149,7 +149,7 @@ class BufferTest {
     @Test
     fun bufferInputStreamByteByByte() {
         val source = Buffer()
-        source.writeUtf8("abc")
+        source.writeString("abc")
         val input: InputStream = source.asInputStream()
         assertEquals(3, input.available())
         assertEquals('a'.code, input.read())
@@ -162,7 +162,7 @@ class BufferTest {
     @Test
     fun bufferInputStreamBulkReads() {
         val source = Buffer()
-        source.writeUtf8("abc")
+        source.writeString("abc")
         val byteArray = ByteArray(4)
         Arrays.fill(byteArray, (-5).toByte())
         val input: InputStream = source.asInputStream()
@@ -176,78 +176,78 @@ class BufferTest {
     @Test
     fun copyToOutputStream() {
         val source = Buffer()
-        source.writeUtf8("party")
+        source.writeString("party")
 
         val target = Buffer()
         source.copyTo(target.asOutputStream())
-        assertEquals("party", target.readUtf8())
-        assertEquals("party", source.readUtf8())
+        assertEquals("party", target.readString())
+        assertEquals("party", source.readString())
     }
 
     @Test
     fun copyToOutputStreamWithStartIndex() {
         val source = Buffer()
-        source.writeUtf8("party")
+        source.writeString("party")
 
         val target = Buffer()
         source.copyTo(target.asOutputStream(), startIndex = 2)
-        assertEquals("rty", target.readUtf8())
-        assertEquals("party", source.readUtf8())
+        assertEquals("rty", target.readString())
+        assertEquals("party", source.readString())
     }
 
     @Test
     fun copyToOutputStreamWithEndIndex() {
         val source = Buffer()
-        source.writeUtf8("party")
+        source.writeString("party")
 
         val target = Buffer()
         source.copyTo(target.asOutputStream(), endIndex = 3)
-        assertEquals("par", target.readUtf8())
-        assertEquals("party", source.readUtf8())
+        assertEquals("par", target.readString())
+        assertEquals("party", source.readString())
     }
 
     @Test
     fun copyToOutputStreamWithIndices() {
         val source = Buffer()
-        source.writeUtf8("party")
+        source.writeString("party")
 
         val target = Buffer()
         source.copyTo(target.asOutputStream(), startIndex = 1, endIndex = 4)
-        assertEquals("art", target.readUtf8())
-        assertEquals("party", source.readUtf8())
+        assertEquals("art", target.readString())
+        assertEquals("party", source.readString())
     }
 
     @Test
     fun copyToOutputStreamWithEmptyRange() {
         val source = Buffer()
-        source.writeUtf8("hello")
+        source.writeString("hello")
 
         val target = Buffer()
         source.copyTo(target.asOutputStream(), startIndex = 1, endIndex = 1)
-        assertEquals("hello", source.readUtf8())
-        assertEquals("", target.readUtf8())
+        assertEquals("hello", source.readString())
+        assertEquals("", target.readString())
     }
 
     @Test
     fun readToOutputStream() {
         val source = Buffer()
-        source.writeUtf8("party")
+        source.writeString("party")
 
         val target = Buffer()
         source.readTo(target.asOutputStream())
-        assertEquals("party", target.readUtf8())
-        assertEquals("", source.readUtf8())
+        assertEquals("party", target.readString())
+        assertEquals("", source.readString())
     }
 
     @Test
     fun readToOutputStreamWithByteCount() {
         val source = Buffer()
-        source.writeUtf8("party")
+        source.writeString("party")
 
         val target = Buffer()
         source.readTo(target.asOutputStream(), byteCount = 3)
-        assertEquals("par", target.readUtf8())
-        assertEquals("ty", source.readUtf8())
+        assertEquals("par", target.readString())
+        assertEquals("ty", source.readString())
     }
 
     @Test

--- a/core/jvm/test/JvmPlatformTest.kt
+++ b/core/jvm/test/JvmPlatformTest.kt
@@ -44,7 +44,7 @@ class JvmPlatformTest {
     fun outputStreamSink() {
         val baos = ByteArrayOutputStream()
         val sink = baos.asSink()
-        sink.write(Buffer().also { it.writeUtf8("a") }, 1L)
+        sink.write(Buffer().also { it.writeString("a") }, 1L)
         assertArrayEquals(baos.toByteArray(), byteArrayOf(0x61))
     }
 
@@ -52,7 +52,7 @@ class JvmPlatformTest {
     fun outputStreamSinkWriteZeroBytes() {
         val baos = ByteArrayOutputStream()
         val sink = baos.asSink()
-        sink.write(Buffer().also { it.writeUtf8("a") }, 0L)
+        sink.write(Buffer().also { it.writeString("a") }, 0L)
         assertEquals(0, baos.size())
     }
 
@@ -61,7 +61,7 @@ class JvmPlatformTest {
         val baos = ByteArrayOutputStream()
         val sink = baos.asSink()
         assertFailsWith<IllegalArgumentException> {
-            sink.write(Buffer().also { it.writeUtf8("a") }, -1)
+            sink.write(Buffer().also { it.writeString("a") }, -1)
         }
     }
 
@@ -69,10 +69,10 @@ class JvmPlatformTest {
     fun outputStreamSinkWritePartOfTheBuffer() {
         val baos = ByteArrayOutputStream()
         val sink = baos.asSink()
-        val buffer = Buffer().also { it.writeUtf8("hello") }
+        val buffer = Buffer().also { it.writeString("hello") }
         sink.write(buffer, 2)
         assertArrayEquals(baos.toByteArray(), byteArrayOf('h'.code.toByte(), 'e'.code.toByte()))
-        assertEquals("llo", buffer.readUtf8())
+        assertEquals("llo", buffer.readString())
     }
 
     @Test
@@ -81,7 +81,7 @@ class JvmPlatformTest {
         val source = bais.asSource()
         val buffer = Buffer()
         source.readAtMostTo(buffer, 1)
-        assertEquals(buffer.readUtf8(), "a")
+        assertEquals(buffer.readString(), "a")
     }
 
     @Test
@@ -104,7 +104,7 @@ class JvmPlatformTest {
     fun fileSink() {
         val file = File(tempDir, "test")
         file.outputStream().asSink().use { sink ->
-            sink.write(Buffer().also { it.writeUtf8("a") }, 1L)
+            sink.write(Buffer().also { it.writeString("a") }, 1L)
         }
         assertEquals(file.readText(), "a")
     }
@@ -114,7 +114,7 @@ class JvmPlatformTest {
         val file = File(tempDir, "test")
         file.writeText("a")
         FileOutputStream(file, true).asSink().use { sink ->
-            sink.write(Buffer().also { it.writeUtf8("b") }, 1L)
+            sink.write(Buffer().also { it.writeString("b") }, 1L)
         }
         assertEquals(file.readText(), "ab")
     }
@@ -127,14 +127,14 @@ class JvmPlatformTest {
         file.inputStream().asSource().use { source ->
             source.readAtMostTo(buffer, 1L)
         }
-        assertEquals(buffer.readUtf8(), "a")
+        assertEquals(buffer.readString(), "a")
     }
 
     @Test
     fun pathSink() {
         val file = File(tempDir, "test")
         file.toPath().outputStream().asSink().use { sink ->
-            sink.write(Buffer().also { it.writeUtf8("a") }, 1L)
+            sink.write(Buffer().also { it.writeString("a") }, 1L)
         }
         assertEquals(file.readText(), "a")
     }
@@ -144,7 +144,7 @@ class JvmPlatformTest {
         val file = File(tempDir, "test")
         file.writeText("a")
         file.toPath().outputStream(StandardOpenOption.APPEND).asSink().use { sink ->
-            sink.write(Buffer().also { it.writeUtf8("b") }, 1L)
+            sink.write(Buffer().also { it.writeString("b") }, 1L)
         }
         assertEquals(file.readText(), "ab")
     }
@@ -157,7 +157,7 @@ class JvmPlatformTest {
         file.toPath().inputStream().asSource().use { source ->
             source.readAtMostTo(buffer, 1L)
         }
-        assertEquals(buffer.readUtf8(), "a")
+        assertEquals(buffer.readString(), "a")
     }
 
     @Test
@@ -173,9 +173,9 @@ class JvmPlatformTest {
         }
 
         assertFailsWith<IOException> {
-            link.toPath().inputStream(LinkOption.NOFOLLOW_LINKS).asSource().use { it.buffered().readUtf8Line() }
+            link.toPath().inputStream(LinkOption.NOFOLLOW_LINKS).asSource().use { it.buffered().readLine() }
         }
-        assertNull(link.toPath().inputStream().asSource().use { it.buffered().readUtf8Line() })
+        assertNull(link.toPath().inputStream().asSource().use { it.buffered().readLine() })
     }
 
     @Test
@@ -185,7 +185,7 @@ class JvmPlatformTest {
             override fun getOutputStream() = baos
         }
         val sink = socket.outputStream.asSink()
-        sink.write(Buffer().also { it.writeUtf8("a") }, 1L)
+        sink.write(Buffer().also { it.writeString("a") }, 1L)
         assertArrayEquals(baos.toByteArray(), byteArrayOf(0x61))
     }
 
@@ -198,6 +198,6 @@ class JvmPlatformTest {
         val source = socket.inputStream.asSource()
         val buffer = Buffer()
         source.readAtMostTo(buffer, 1L)
-        assertEquals(buffer.readUtf8(), "a")
+        assertEquals(buffer.readString(), "a")
     }
 }

--- a/core/jvm/test/NioTest.kt
+++ b/core/jvm/test/NioTest.kt
@@ -65,7 +65,7 @@ class NioTest {
         val fileChannel: FileChannel = FileChannel.open(file, StandardOpenOption.WRITE)
         testWritableByteChannel(false, fileChannel)
         val emitted: Source = file.inputStream().asSource().buffered()
-        assertEquals("defghijklmnopqrstuvw", emitted.readUtf8())
+        assertEquals("defghijklmnopqrstuvw", emitted.readString())
         emitted.close()
     }
 
@@ -73,7 +73,7 @@ class NioTest {
     fun writableChannelBuffer() {
         val buffer = Buffer()
         testWritableByteChannel(true, buffer.asByteChannel())
-        assertEquals("defghijklmnopqrstuvw", buffer.readUtf8())
+        assertEquals("defghijklmnopqrstuvw", buffer.readString())
     }
 
     @Test
@@ -81,14 +81,14 @@ class NioTest {
         val buffer = Buffer()
         val bufferedSink: Sink = buffer
         testWritableByteChannel(true, bufferedSink.asByteChannel())
-        assertEquals("defghijklmnopqrstuvw", buffer.readUtf8())
+        assertEquals("defghijklmnopqrstuvw", buffer.readString())
     }
 
     @Test
     fun readableChannelNioFile() {
         val file: File = Paths.get(temporaryFolder.toString(), "test").toFile()
         val initialData: Sink = file.outputStream().asSink().buffered()
-        initialData.writeUtf8("abcdefghijklmnopqrstuvwxyz")
+        initialData.writeString("abcdefghijklmnopqrstuvwxyz")
         initialData.close()
         val fileChannel: FileChannel = FileChannel.open(file.toPath(), StandardOpenOption.READ)
         testReadableByteChannel(false, fileChannel)
@@ -97,7 +97,7 @@ class NioTest {
     @Test
     fun readableChannelBuffer() {
         val buffer = Buffer()
-        buffer.writeUtf8("abcdefghijklmnopqrstuvwxyz")
+        buffer.writeString("abcdefghijklmnopqrstuvwxyz")
         testReadableByteChannel(true, buffer.asByteChannel())
     }
 
@@ -105,7 +105,7 @@ class NioTest {
     fun readableChannelBufferedSource() {
         val buffer = Buffer()
         val bufferedSource: Source = buffer
-        buffer.writeUtf8("abcdefghijklmnopqrstuvwxyz")
+        buffer.writeString("abcdefghijklmnopqrstuvwxyz")
         testReadableByteChannel(true, bufferedSource.asByteChannel())
     }
 


### PR DESCRIPTION
Closes https://github.com/Kotlin/kotlinx-io/issues/155; see the ticket for the rationale.