### PR TITLE
Use lower case letters for hex-formatted ByteStrings

### DIFF
--- a/bytestring/common/src/ByteString.kt
+++ b/bytestring/common/src/ByteString.kt
@@ -79,7 +79,7 @@ public class ByteString private constructor(
 
         internal fun wrap(byteArray: ByteArray): ByteString = ByteString(byteArray, null)
 
-        private val HEX_DIGITS = "0123456789ABCDEF".toCharArray()
+        private val HEX_DIGITS = "0123456789abcdef".toCharArray()
     }
 
     /**

--- a/bytestring/common/test/ByteStringTest.kt
+++ b/bytestring/common/test/ByteStringTest.kt
@@ -379,7 +379,7 @@ class ByteStringTest {
         assertEquals("ByteString(size=0)", ByteString().toString())
         assertEquals("ByteString(size=1 hex=00)", ByteString(0).toString())
         assertEquals(
-            "ByteString(size=16 hex=000102030405060708090A0B0C0D0E0F)",
+            "ByteString(size=16 hex=000102030405060708090a0b0c0d0e0f)",
             ByteString(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).toString()
         )
         assertEquals(


### PR DESCRIPTION
Buffer's use lower-case characters, stdlib's `HexFormat` use lower-case characters by default too.

Fixed case of the characters appearing in `ByteString::toString` for consistency.