### PR TITLE
Explicitly annotate all benchmark classes w/ State

### DIFF
--- a/benchmarks/src/commonMain/kotlin/BufferOps.kt
+++ b/benchmarks/src/commonMain/kotlin/BufferOps.kt
@@ -36,6 +36,7 @@ abstract class BufferRWBenchmarkBase {
     }
 }
 
+@State(Scope.Benchmark)
 open class ByteBenchmark : BufferRWBenchmarkBase() {
     @Benchmark
     fun benchmark(): Byte {
@@ -44,6 +45,7 @@ open class ByteBenchmark : BufferRWBenchmarkBase() {
     }
 }
 
+@State(Scope.Benchmark)
 open class ShortBenchmark : BufferRWBenchmarkBase() {
     @Benchmark
     fun benchmark(): Short {
@@ -52,6 +54,7 @@ open class ShortBenchmark : BufferRWBenchmarkBase() {
     }
 }
 
+@State(Scope.Benchmark)
 open class IntBenchmark : BufferRWBenchmarkBase() {
     @Benchmark
     fun benchmark(): Int {
@@ -60,6 +63,7 @@ open class IntBenchmark : BufferRWBenchmarkBase() {
     }
 }
 
+@State(Scope.Benchmark)
 open class LongBenchmark : BufferRWBenchmarkBase() {
     @Benchmark
     fun benchmark(): Long {
@@ -68,6 +72,7 @@ open class LongBenchmark : BufferRWBenchmarkBase() {
     }
 }
 
+@State(Scope.Benchmark)
 open class ShortLeBenchmark : BufferRWBenchmarkBase() {
     @Benchmark
     fun benchmark(): Short {
@@ -76,6 +81,7 @@ open class ShortLeBenchmark : BufferRWBenchmarkBase() {
     }
 }
 
+@State(Scope.Benchmark)
 open class IntLeBenchmark : BufferRWBenchmarkBase() {
     @Benchmark
     fun benchmark(): Int {
@@ -84,6 +90,7 @@ open class IntLeBenchmark : BufferRWBenchmarkBase() {
     }
 }
 
+@State(Scope.Benchmark)
 open class LongLeBenchmark : BufferRWBenchmarkBase() {
     @Benchmark
     fun benchmark(): Long {
@@ -92,6 +99,7 @@ open class LongLeBenchmark : BufferRWBenchmarkBase() {
     }
 }
 
+@State(Scope.Benchmark)
 open class DecimalLongBenchmark : BufferRWBenchmarkBase() {
     @Param("-9223372036854775806", "9223372036854775806", "1")
     var value = 0L
@@ -118,6 +126,7 @@ open class DecimalLongBenchmark : BufferRWBenchmarkBase() {
     }
 }
 
+@State(Scope.Benchmark)
 open class HexadecimalLongBenchmark : BufferRWBenchmarkBase() {
     @Param("9223372036854775806", "1")
     var value = 0L
@@ -144,6 +153,7 @@ open class HexadecimalLongBenchmark : BufferRWBenchmarkBase() {
 
 // This benchmark is based on Okio benchmark:
 // https://raw.githubusercontent.com/square/okio/master/okio/jvm/jmh/src/jmh/java/com/squareup/okio/benchmarks/BufferUtf8Benchmark.java
+@State(Scope.Benchmark)
 open class Utf8StringBenchmark : BufferRWBenchmarkBase() {
     private val strings = mapOf(
         "ascii" to ("Um, I'll tell you the problem with the scientific power that you're using here, "
@@ -219,6 +229,7 @@ open class Utf8StringBenchmark : BufferRWBenchmarkBase() {
     }
 }
 
+@State(Scope.Benchmark)
 open class Utf8LineBenchmarkBase : BufferRWBenchmarkBase() {
     @Param("17")
     var length: Int = 0
@@ -254,6 +265,7 @@ open class Utf8LineBenchmarkBase : BufferRWBenchmarkBase() {
     }
 }
 
+@State(Scope.Benchmark)
 open class Utf8LineBenchmark : Utf8LineBenchmarkBase() {
     @Benchmark
     fun benchmark(): String? {
@@ -262,6 +274,7 @@ open class Utf8LineBenchmark : Utf8LineBenchmarkBase() {
     }
 }
 
+@State(Scope.Benchmark)
 open class Utf8LineStrictBenchmark : Utf8LineBenchmarkBase() {
     @Benchmark
     fun benchmark(): String {
@@ -331,6 +344,7 @@ open class BufferGetBenchmark {
     fun get() = buffer[offset]
 }
 
+@State(Scope.Benchmark)
 open class BufferReadWriteByteArray : BufferRWBenchmarkBase() {
     private var inputArray = ByteArray(0)
     private var outputArray = ByteArray(0)
@@ -352,6 +366,7 @@ open class BufferReadWriteByteArray : BufferRWBenchmarkBase() {
     }
 }
 
+@State(Scope.Benchmark)
 open class BufferReadNewByteArray : BufferRWBenchmarkBase() {
     private var inputArray = ByteArray(0)
 

--- a/benchmarks/src/commonMain/kotlin/PeekBenchmark.kt
+++ b/benchmarks/src/commonMain/kotlin/PeekBenchmark.kt
@@ -5,8 +5,9 @@
 
 package kotlinx.io.benchmarks
 
-import kotlinx.io.*
 import kotlinx.benchmark.*
+import kotlinx.io.Buffer
+import kotlinx.io.Source
 
 const val OFFSET_TO_LAST_BYTE_IN_SEGMENT = (SEGMENT_SIZE_IN_BYTES - 1).toString()
 
@@ -31,21 +32,25 @@ abstract class PeekBenchmark {
     }
 }
 
+@State(Scope.Benchmark)
 open class PeekByteBenchmark : PeekBenchmark() {
     @Benchmark
     fun benchmark() = peek().readByte()
 }
 
+@State(Scope.Benchmark)
 open class PeekShortBenchmark : PeekBenchmark() {
     @Benchmark
     fun benchmark() = peek().readShort()
 }
 
+@State(Scope.Benchmark)
 open class PeekIntBenchmark : PeekBenchmark() {
     @Benchmark
     fun benchmark() = peek().readInt()
 }
 
+@State(Scope.Benchmark)
 open class PeekLongBenchmark : PeekBenchmark() {
     @Benchmark
     fun benchmark() = peek().readLong()


### PR DESCRIPTION
Currently, not all benchmarks could be executed on native targets because only a few of them are explicitly annotated with @State. The majority of benchmarks inherit that annotation from a base class. It works fine w/ JMH, but doesn't work for native targets.

The change will make all benchmarks executable on native targets.