### PR TITLE
Workaround for expanded lock on Windows

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.konan.target.KonanTarget
 plugins {
     kotlin("multiplatform")
     alias(libs.plugins.kotlinx.benchmark.plugin)
+    id("kotlinx-io-clean")
 }
 
 kotlin {

--- a/build-logic/src/main/kotlin/kotlinx/io/conventions/kotlinx-io-clean.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlinx/io/conventions/kotlinx-io-clean.gradle.kts
@@ -3,19 +3,13 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
-import org.gradle.api.tasks.Delete
-import org.gradle.kotlin.dsl.invoke
-import org.gradle.kotlin.dsl.named
-import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
-
-if (DefaultNativePlatform.getCurrentOperatingSystem().isWindows) {
-    tasks {
-        // Workaround for https://youtrack.jetbrains.com/issue/KT-58303:
-        // the `clean` task can't delete the expanded.lock file on Windows as it's still held by Gradle, failing the build
-        named("clean", Delete::class) {
-            setDelete(fileTree(buildDir) {
-                exclude("tmp/.cache/expanded/expanded.lock")
-            })
-        }
+tasks {
+    // Workaround for https://youtrack.jetbrains.com/issue/KT-58303:
+    // the `clean` task can't delete the expanded.lock file on Windows as it's still held by Gradle, failing the build
+    named("clean", Delete::class) {
+        setDelete(fileTree(buildDir) {
+            exclude("tmp/.cache/expanded/expanded.lock")
+        })
     }
 }
+

--- a/build-logic/src/main/kotlin/kotlinx/io/conventions/kotlinx-io-clean.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlinx/io/conventions/kotlinx-io-clean.gradle.kts
@@ -7,7 +7,7 @@ tasks {
     // Workaround for https://youtrack.jetbrains.com/issue/KT-58303:
     // the `clean` task can't delete the expanded.lock file on Windows as it's still held by Gradle, failing the build
     named("clean", Delete::class) {
-        setDelete(fileTree(buildDir) {
+        setDelete(layout.buildDirectory.asFileTree.matching {
             exclude("tmp/.cache/expanded/expanded.lock")
         })
     }

--- a/build-logic/src/main/kotlin/kotlinx/io/conventions/kotlinx-io-clean.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlinx/io/conventions/kotlinx-io-clean.gradle.kts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+import org.gradle.api.tasks.Delete
+import org.gradle.kotlin.dsl.invoke
+import org.gradle.kotlin.dsl.named
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+
+if (DefaultNativePlatform.getCurrentOperatingSystem().isWindows) {
+    tasks {
+        // Workaround for https://youtrack.jetbrains.com/issue/KT-58303:
+        // the `clean` task can't delete the expanded.lock file on Windows as it's still held by Gradle, failing the build
+        named("clean", Delete::class) {
+            setDelete(fileTree(buildDir) {
+                exclude("tmp/.cache/expanded/expanded.lock")
+            })
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/kotlinx/io/conventions/kotlinx-io-clean.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlinx/io/conventions/kotlinx-io-clean.gradle.kts
@@ -3,13 +3,15 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
-tasks {
+plugins {
+    base
+}
+
+tasks.clean {
     // Workaround for https://youtrack.jetbrains.com/issue/KT-58303:
     // the `clean` task can't delete the expanded.lock file on Windows as it's still held by Gradle, failing the build
-    named("clean", Delete::class) {
-        setDelete(layout.buildDirectory.asFileTree.matching {
-            exclude("tmp/.cache/expanded/expanded.lock")
-        })
-    }
+    setDelete(layout.buildDirectory.asFileTree.matching {
+        exclude("tmp/.cache/expanded/expanded.lock")
+    })
 }
 

--- a/build-logic/src/main/kotlin/kotlinx/io/conventions/kotlinx-io-multiplatform.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlinx/io/conventions/kotlinx-io-multiplatform.gradle.kts
@@ -3,13 +3,13 @@
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENCE file.
  */
 
-import org.gradle.kotlin.dsl.kotlin
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import kotlin.jvm.optionals.getOrNull
 
 plugins {
     kotlin("multiplatform")
+    id("kotlinx-io-clean")
 }
 
 kotlin {


### PR DESCRIPTION
After upgrading the Gradle, jobs are intermittently failing on Windows with the following error:
```
Execution failed for task ':kotlinx-io-benchmarks:clean'. org.gradle.api.UncheckedIOException: java.io.IOException: Unable to delete directory 'Z:\BuildAgent\work\22e3a7db6b861ba7\benchmarks\build'
  Failed to delete some children. This might happen because a process has files open or has its working directory set in the target directory.
  - Z:\BuildAgent\work\22e3a7db6b861ba7\benchmarks\build\tmp\.cache\expanded\expanded.lock
  - Z:\BuildAgent\work\22e3a7db6b861ba7\benchmarks\build\tmp\.cache\expanded
  - Z:\BuildAgent\work\22e3a7db6b861ba7\benchmarks\build\tmp\.cache
  - Z:\BuildAgent\work\22e3a7db6b861ba7\benchmarks\build\tmp
```

Picked the workaround from `kotlinx-datetime`: https://github.com/Kotlin/kotlinx-datetime/blob/94bcc6ff1733c22ef4f937a25a276d3fd728a301/core/build.gradle.kts#L297C19-L297C19