### PR TITLE
Bump up kotlinx-benchmark version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ java = "8"
 dokka = "1.8.20"
 kover = "0.7.1"
 bcv = "0.13.2"
-benchmark = "0.4.8"
+benchmark = "0.4.9"
 jmh = "1.36"
 
 [libraries]


### PR DESCRIPTION
Upgraded kotlinx-benchmark to a version supporting Kotlin 1.9.0.
Didn't enable native benchmarks by default because issue with stability is still there.