### PR TITLE
Fix potential UB in ByteString.hashCode

### DIFF
--- a/bytestring/common/src/-Platform.kt
+++ b/bytestring/common/src/-Platform.kt
@@ -5,7 +5,7 @@
 package kotlinx.io.bytestring
 
 /**
- * Annotation indicating that the marked property is the subjectof benign data race.
+ * Annotation indicating that the marked property is the subject of benign data race.
  * LLVM does not support this notion, so on K/N platforms we alias it into `@Volatile` to prevent potential OoTA.
  */
 @OptionalExpectation

--- a/bytestring/common/src/-Platform.kt
+++ b/bytestring/common/src/-Platform.kt
@@ -1,0 +1,14 @@
+/*
+* Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+* Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+*/
+package kotlinx.io.bytestring
+
+/**
+ * Annotation indicating that the marked property is the subjectof benign data race.
+ * LLVM does not support this notion, so on K/N platforms we alias it into `@Volatile` to prevent potential OoTA.
+ */
+@OptionalExpectation
+@Target(AnnotationTarget.FIELD)
+@OptIn(ExperimentalMultiplatform::class)
+internal expect annotation class BenignDataRace()

--- a/bytestring/common/src/ByteString.kt
+++ b/bytestring/common/src/ByteString.kt
@@ -21,7 +21,6 @@
 
 package kotlinx.io.bytestring
 
-import kotlin.concurrent.Volatile
 import kotlin.math.max
 import kotlin.math.min
 
@@ -70,7 +69,7 @@ public class ByteString private constructor(
     public constructor(data: ByteArray, startIndex: Int = 0, endIndex: Int = data.size) :
             this(data.copyOfRange(startIndex, endIndex), null)
 
-    @Volatile
+    @BenignDataRace
     private var hashCode: Int = 0
 
     public companion object {

--- a/bytestring/common/src/ByteString.kt
+++ b/bytestring/common/src/ByteString.kt
@@ -21,6 +21,7 @@
 
 package kotlinx.io.bytestring
 
+import kotlin.concurrent.Volatile
 import kotlin.math.max
 import kotlin.math.min
 
@@ -69,6 +70,7 @@ public class ByteString private constructor(
     public constructor(data: ByteArray, startIndex: Int = 0, endIndex: Int = data.size) :
             this(data.copyOfRange(startIndex, endIndex), null)
 
+    @Volatile
     private var hashCode: Int = 0
 
     public companion object {

--- a/bytestring/native/src/-PlatformNative.kt
+++ b/bytestring/native/src/-PlatformNative.kt
@@ -1,0 +1,10 @@
+/*
+* Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+* Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+*/
+package kotlinx.io.bytestring
+
+import kotlin.concurrent.*
+
+@Suppress("ACTUAL_WITHOUT_EXPECT") // This suppress can be removed in 2.0: KT-59355
+internal actual typealias BenignDataRace = Volatile


### PR DESCRIPTION
It has a benign JVM data-race on the hashCode field, but on K/N LLVM has no guarantees it will read default or written value (e.g. OoTA is one of the possibilities). The recommendation from K/N folks is to use @Volatile here

Fixes #190