### PR TITLE
Correctly extract parent path on Windows

### DIFF
--- a/core/android/src/files/FileSystemAndroid.kt
+++ b/core/android/src/files/FileSystemAndroid.kt
@@ -12,6 +12,9 @@ import platform.posix.dirname
 
 @OptIn(ExperimentalForeignApi::class)
 internal actual fun dirnameImpl(path: String): String {
+    if (!path.contains(SystemPathSeparator)) {
+        return ""
+    }
     return dirname(path)?.toKString() ?: ""
 }
 

--- a/core/apple/src/files/FileSystemApple.kt
+++ b/core/apple/src/files/FileSystemApple.kt
@@ -25,6 +25,9 @@ public actual val SystemTemporaryDirectory: Path
     get() = Path(NSTemporaryDirectory())
 
 internal actual fun dirnameImpl(path: String): String {
+    if (!path.contains(SystemPathSeparator)) {
+        return ""
+    }
     memScoped {
         return dirname(path.cstr.ptr)?.toKString() ?: ""
     }

--- a/core/common/test/files/SmokeFileTest.kt
+++ b/core/common/test/files/SmokeFileTest.kt
@@ -176,7 +176,6 @@ class SmokeFileTest {
         val p1 = Path("home", "..", "lib")
         assertEquals(constructRelativePath("home", ".."), p1.parent?.toString())
         assertEquals("home", p1.parent?.parent?.toString())
-        println(p1)
         assertNull(p1.parent?.parent?.parent)
 
         assertNull(Path("").parent)

--- a/core/common/test/files/SmokeFileTest.kt
+++ b/core/common/test/files/SmokeFileTest.kt
@@ -176,6 +176,7 @@ class SmokeFileTest {
         val p1 = Path("home", "..", "lib")
         assertEquals(constructRelativePath("home", ".."), p1.parent?.toString())
         assertEquals("home", p1.parent?.parent?.toString())
+        println(p1)
         assertNull(p1.parent?.parent?.parent)
 
         assertNull(Path("").parent)

--- a/core/linux/src/files/FileSystemLinux.kt
+++ b/core/linux/src/files/FileSystemLinux.kt
@@ -14,6 +14,9 @@ import platform.posix.dirname
 
 @OptIn(ExperimentalForeignApi::class)
 internal actual fun dirnameImpl(path: String): String {
+    if (!path.contains(SystemPathSeparator)) {
+        return ""
+    }
     memScoped {
         return dirname(path.cstr.ptr)?.toKString() ?: ""
     }

--- a/core/mingw/src/files/FileSystemMingw.kt
+++ b/core/mingw/src/files/FileSystemMingw.kt
@@ -15,6 +15,8 @@ import platform.windows.MOVEFILE_REPLACE_EXISTING
 import platform.windows.MoveFileExA
 import platform.windows.PathIsRelativeA
 
+private const val WindowsPathSeparator: Char = '\\'
+
 internal actual fun atomicMoveImpl(source: Path, destination: Path) {
     if (MoveFileExA(source.path, destination.path, MOVEFILE_REPLACE_EXISTING.convert()) == 0) {
         // TODO: get formatted error message
@@ -23,6 +25,9 @@ internal actual fun atomicMoveImpl(source: Path, destination: Path) {
 }
 
 internal actual fun dirnameImpl(path: String): String {
+    if (!path.contains(SystemPathSeparator) && !path.contains(WindowsPathSeparator)) {
+        return ""
+    }
     memScoped {
         return dirname(path.cstr.ptr)?.toKString() ?: ""
     }

--- a/core/mingw/test/files/SmokeFileTestWindows.kt
+++ b/core/mingw/test/files/SmokeFileTestWindows.kt
@@ -25,5 +25,6 @@ class SmokeFileTestWindows {
         assertNull(Path("a\\b").parent?.parent)
         assertEquals(Path("\\\\server"), Path("\\\\server\\share").parent)
         assertEquals(Path("C:\\"), Path("C:\\Program Files").parent)
+        assertEquals(Path("C:\\Program Files"), Path("C:\\Program Files/Java").parent)
     }
 }

--- a/core/mingw/test/files/SmokeFileTestWindows.kt
+++ b/core/mingw/test/files/SmokeFileTestWindows.kt
@@ -5,9 +5,7 @@
 
 package kotlinx.io.files
 
-import kotlin.test.Test
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 class SmokeFileTestWindows {
     @Test
@@ -19,5 +17,13 @@ class SmokeFileTestWindows {
         assertTrue(Path("C:file").isAbsolute)
         assertFalse(Path("bla\\bla\\bla").isAbsolute)
         assertTrue(Path("\\\\server\\share").isAbsolute)
+    }
+
+    @Test
+    fun getParent() {
+        assertNull(Path("C:\\").parent)
+        assertNull(Path("a\\b").parent?.parent)
+        assertEquals(Path("\\\\server"), Path("\\\\server\\share").parent)
+        assertEquals(Path("C:\\"), Path("C:\\Program Files").parent)
     }
 }

--- a/core/native/src/files/PathsNative.kt
+++ b/core/native/src/files/PathsNative.kt
@@ -23,7 +23,6 @@ public actual class Path internal constructor(
         get() {
             when {
                 path.isBlank() -> return null
-                !path.contains(SystemPathSeparator) -> return null
             }
             val parentName = dirnameImpl(path)
             return when {


### PR DESCRIPTION
Previously, shared native `Path.parent` implementation could filter out a windows path using `\` as a separator. 

This behavior was fixed to correctly process paths using both `\` and `/` on Windows.

Fixes #221