### PR TITLE
Reimplement Source::indexOf(ByteString) without Source::peek calls

### DIFF
--- a/benchmarks/src/commonMain/kotlin/BufferOps.kt
+++ b/benchmarks/src/commonMain/kotlin/BufferOps.kt
@@ -393,6 +393,7 @@ open class IndexOfByteString {
 
     private var buffer = Buffer()
     private var byteString = ByteString()
+    private var source: Source = buffer
 
     @Setup
     fun setup() {
@@ -413,5 +414,5 @@ open class IndexOfByteString {
     }
 
     @Benchmark
-    fun benchmark() = buffer.indexOf(byteString)
+    fun benchmark() = source.indexOf(byteString)
 }

--- a/core/api/kotlinx-io-core.api
+++ b/core/api/kotlinx-io-core.api
@@ -54,7 +54,9 @@ public final class kotlinx/io/BuffersKt {
 }
 
 public final class kotlinx/io/ByteStringsKt {
+	public static final fun indexOf (Lkotlinx/io/Buffer;Lkotlinx/io/bytestring/ByteString;J)J
 	public static final fun indexOf (Lkotlinx/io/Source;Lkotlinx/io/bytestring/ByteString;J)J
+	public static synthetic fun indexOf$default (Lkotlinx/io/Buffer;Lkotlinx/io/bytestring/ByteString;JILjava/lang/Object;)J
 	public static synthetic fun indexOf$default (Lkotlinx/io/Source;Lkotlinx/io/bytestring/ByteString;JILjava/lang/Object;)J
 	public static final fun readByteString (Lkotlinx/io/Source;)Lkotlinx/io/bytestring/ByteString;
 	public static final fun readByteString (Lkotlinx/io/Source;I)Lkotlinx/io/bytestring/ByteString;

--- a/core/common/src/ByteStrings.kt
+++ b/core/common/src/ByteStrings.kt
@@ -102,38 +102,62 @@ public fun Source.indexOf(byteString: ByteString, startIndex: Long = 0): Long {
     }
 
     var offset = startIndex
-    val peek = peek()
-    if (!request(startIndex)) {
-        return -1L
-    }
-    peek.skip(offset)
-    var resultingIndex = -1L
-    UnsafeByteStringOperations.withByteArrayUnsafe(byteString) { data ->
-        while (!peek.exhausted()) {
-            val index = peek.indexOf(data[0])
-            if (index == -1L) {
-                return@withByteArrayUnsafe
-            }
-            offset += index
-            peek.skip(index)
-            if (!peek.request(byteString.size.toLong())) {
-                return@withByteArrayUnsafe
-            }
-
-            var matches = true
-            for (idx in data.indices) {
-                if (data[idx] != peek.buffer[idx.toLong()]) {
-                    matches = false
-                    offset++
-                    peek.skip(1)
-                    break
-                }
-            }
-            if (matches) {
-                resultingIndex = offset
-                return@withByteArrayUnsafe
-            }
+    while (request(offset + byteString.size)) {
+        val idx = buffer.indexOf(byteString, offset)
+        if (idx < 0) {
+            // The buffer does not contain the pattern, let's try fetching at least one extra byte
+            // and start a new search attempt so that the pattern would fit in the suffix of
+            // the current buffer + 1 extra byte.
+            offset = buffer.size - byteString.size + 1
+        } else {
+            return idx
         }
     }
-    return resultingIndex
+    return -1
+}
+
+@OptIn(UnsafeByteStringApi::class)
+public fun Buffer.indexOf(byteString: ByteString, startIndex: Long = 0): Long {
+    require(startIndex <= size) {
+        "startIndex ($startIndex) should not exceed size ($size)"
+    }
+    if (byteString.isEmpty()) return 0
+    if (startIndex > size - byteString.size) return -1L
+
+    UnsafeByteStringOperations.withByteArrayUnsafe(byteString) { byteStringData ->
+        seek(startIndex) { seg, o ->
+            if (o == -1L) {
+                return -1L
+            }
+            var segment = seg!!
+            var offset = o
+            do {
+                // If start index within this segment, the diff will be positive and
+                // we'll scan the segment starting from the corresponding offset.
+                // Otherwise, the diff will be negative and we'll scan the segment from the beginning.
+                val startOffset = maxOf((startIndex - offset).toInt(), 0)
+                // Try to search the pattern within the current segment.
+                val idx = segment.indexOfBytesInbound(byteStringData, startOffset)
+                if (idx != -1) {
+                    // The offset corresponds to the segment's start, idx - to offset within the segment.
+                    return offset + idx.toLong()
+                }
+                // Try to find a pattern in all suffixes shorter than the pattern. These suffixes start
+                // in the current segment, but ends in the following segments; thus we're using outbound function.
+                for (spanningIdx in maxOf(startOffset, segment.size - byteStringData.size + 1) until segment.size) {
+                    val idx1 = segment.indexOfBytesOutbound(byteStringData, spanningIdx, head)
+                    if (idx1 != -1) {
+                        // Offset corresponds to the segment's start, idx - to offset within the segment.
+                        return offset + idx1.toLong()
+                    }
+                }
+
+                // We scanned the whole segment, so let's go to the next one
+                offset += segment.size
+                segment = segment.next!!
+            } while (segment !== head && offset + byteString.size <= size)
+            return -1L
+        }
+    }
+    return -1
 }

--- a/core/common/test/AbstractSourceTest.kt
+++ b/core/common/test/AbstractSourceTest.kt
@@ -1769,4 +1769,15 @@ abstract class AbstractBufferedSourceTest internal constructor(
         assertEquals((Segment.SIZE * 2 + 1).toLong(), source.indexOf("fg".encodeToByteString()))
         assertEquals((Segment.SIZE * 2 + 2).toLong(), source.indexOf("g".encodeToByteString()))
     }
+
+    @Test
+    fun indexOfByteStringSpanningAcrossMultipleSegments() {
+        sink.writeString("a".repeat(SEGMENT_SIZE - 1))
+        val target = "b".repeat(SEGMENT_SIZE + 2)
+        sink.writeString(target)
+        sink.writeString("c".repeat(SEGMENT_SIZE - 1))
+        sink.emit()
+
+        assertEquals((SEGMENT_SIZE - 1).toLong(), source.indexOf(target.encodeToByteString()))
+    }
 }

--- a/core/common/test/AbstractSourceTest.kt
+++ b/core/common/test/AbstractSourceTest.kt
@@ -1772,12 +1772,14 @@ abstract class AbstractBufferedSourceTest internal constructor(
 
     @Test
     fun indexOfByteStringSpanningAcrossMultipleSegments() {
-        sink.writeString("a".repeat(SEGMENT_SIZE - 1))
-        val target = "b".repeat(SEGMENT_SIZE + 2)
-        sink.writeString(target)
-        sink.writeString("c".repeat(SEGMENT_SIZE - 1))
+        sink.writeString("a".repeat(SEGMENT_SIZE))
+        sink.emit()
+        sink.writeString("bbbb")
+        sink.emit()
+        sink.write(Buffer().also { it.writeString("c".repeat(SEGMENT_SIZE)) }, SEGMENT_SIZE.toLong())
         sink.emit()
 
-        assertEquals((SEGMENT_SIZE - 1).toLong(), source.indexOf(target.encodeToByteString()))
+        source.skip(SEGMENT_SIZE - 10L)
+        assertEquals(9, source.indexOf("abbbbc".encodeToByteString()))
     }
 }


### PR DESCRIPTION
As in https://github.com/Kotlin/kotlinx-io/pull/240, reimplemented algorithm without the use of the `PeekSource`. Also added a specialized implementation for `Buffer`.