### PR TITLE
Simplify Dokka source link configuration

### DIFF
--- a/build-logic/src/main/kotlin/kotlinx/io/conventions/kotlinx-io-dokka.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlinx/io/conventions/kotlinx-io-dokka.gradle.kts
@@ -14,17 +14,10 @@ tasks.withType<DokkaTaskPartial>().configureEach {
     dokkaSourceSets.configureEach {
         includes.from("Module.md")
 
-        if (name.endsWith("Main")) {
-            sourceLink {
-                // sources are located in projectDir/PLATFORM/src
-                // where the PLATFORM could be jvm, js, darwin, etc.
-                // configuration happens in kotlinx-io-multiplatform.gradle.kts:KotlinSourceSet.configureSourceSet
-                val platform = name.dropLast(4)
-                val relPath = rootProject.projectDir.toPath().relativize(projectDir.toPath())
-                localDirectory.set(projectDir.resolve("$platform/src"))
-                remoteUrl.set(URL("https://github.com/kotlin/kotlinx-io/tree/master/$relPath/$platform/src"))
-                remoteLineSuffix.set("#L")
-            }
+        sourceLink {
+            localDirectory.set(rootDir)
+            remoteUrl.set(URL("https://github.com/kotlin/kotlinx-io/tree/master"))
+            remoteLineSuffix.set("#L")
         }
     }
 }


### PR DESCRIPTION
Based on discussion: https://github.com/Kotlin/kotlinx-datetime/pull/323#discussion_r1412147614

Checked locally - content is identical for both approaches