### PR TITLE
Don't build JS and Wasm executable files

### DIFF
--- a/build-logic/src/main/kotlin/kotlinx/io/conventions/kotlinx-io-multiplatform.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlinx/io/conventions/kotlinx-io-multiplatform.gradle.kts
@@ -43,13 +43,11 @@ kotlin {
         nodejs()
         //  Disabled because we can't exclude some tests: https://youtrack.jetbrains.com/issue/KT-58291
         // browser()
-        binaries.executable()
     }
 
     @OptIn(org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl::class)
     wasmWasi {
         nodejs()
-        binaries.executable()
     }
 
     sourceSets {


### PR DESCRIPTION
There's absolutely no sense in building executable Wasm and Js binaries as `kotlinx-io` is a library and not supposed to be executed on its own.

Kudos to @lppedd for spotting the issue.