### PR TITLE
Align file sink and source creation behavior across targets

### DIFF
--- a/core/common/test/files/SmokeFileTest.kt
+++ b/core/common/test/files/SmokeFileTest.kt
@@ -50,9 +50,7 @@ class SmokeFileTest {
     @Test
     fun readNotExistingFile() {
         assertFailsWith<FileNotFoundException> {
-            SystemFileSystem.source(createTempPath()).buffered().use {
-                it.readByte()
-            }
+            SystemFileSystem.source(createTempPath())
         }
     }
 

--- a/core/common/test/files/SmokeFileTest.kt
+++ b/core/common/test/files/SmokeFileTest.kt
@@ -380,6 +380,24 @@ class SmokeFileTest {
         assertTrue(SystemFileSystem.metadataOrNull(path)!!.isRegularFile)
     }
 
+    @Test
+    fun closeFileSinkTwice() {
+        val path = createTempPath()
+        val sink = SystemFileSystem.sink(path)
+        sink.close()
+        sink.close() // there should be no error
+    }
+
+    @Test
+    fun closeFileSourceTwice() {
+        val path = createTempPath()
+        SystemFileSystem.sink(path).close()
+        assertTrue(SystemFileSystem.exists(path))
+        val source = SystemFileSystem.source(path)
+        source.close()
+        source.close()  // there should be no error
+    }
+
     private fun constructAbsolutePath(vararg parts: String): String {
         return SystemPathSeparator.toString() + parts.joinToString(SystemPathSeparator.toString())
     }

--- a/core/common/test/files/SmokeFileTest.kt
+++ b/core/common/test/files/SmokeFileTest.kt
@@ -372,6 +372,16 @@ class SmokeFileTest {
         }
     }
 
+    @Test
+    fun createAnEmptyFileUsingSink() {
+        val path = createTempPath()
+        assertFalse(SystemFileSystem.exists(path))
+
+        SystemFileSystem.sink(path).close()
+        assertTrue(SystemFileSystem.exists(path))
+        assertTrue(SystemFileSystem.metadataOrNull(path)!!.isRegularFile)
+    }
+
     private fun constructAbsolutePath(vararg parts: String): String {
         return SystemPathSeparator.toString() + parts.joinToString(SystemPathSeparator.toString())
     }

--- a/core/js/src/files/PathsJs.kt
+++ b/core/js/src/files/PathsJs.kt
@@ -94,12 +94,12 @@ internal class FileSource(private val path: Path) : RawSource {
     private var offset = 0
     private val fd = open(path)
 
-    private fun open(path: Path): Int {
+    private fun open(path: Path): dynamic {
         if (!(fs.existsSync(path.path) as Boolean)) {
             throw FileNotFoundException("File does not exist: $path")
         }
         val fd = try {
-            fs.openSync(path.path, "r") as Int
+            fs.openSync(path.path, "r")
         } catch (e: Throwable) {
             throw IOException("Failed to open a file $path.", e)
         }
@@ -107,7 +107,6 @@ internal class FileSource(private val path: Path) : RawSource {
         return fd
     }
 
-    @OptIn(ExperimentalUnsignedTypes::class)
     override fun readAtMostTo(sink: Buffer, byteCount: Long): Long {
         check(!closed) { "Source is closed." }
         if (byteCount == 0L) {
@@ -142,10 +141,10 @@ internal class FileSink(path: Path, append: Boolean) : RawSink {
     private var closed = false
     private val fd = open(path, append)
 
-    private fun open(path: Path, append: Boolean): Int {
+    private fun open(path: Path, append: Boolean): dynamic {
         val flags = if (append) "a" else "w"
         val fd = try {
-            fs.openSync(path.path, flags) as Int
+            fs.openSync(path.path, flags)
         } catch (e: Throwable) {
             throw IOException("Failed to open a file ${path.path}.", e)
         }

--- a/core/js/src/files/PathsJs.kt
+++ b/core/js/src/files/PathsJs.kt
@@ -96,14 +96,14 @@ internal class FileSource(private val path: Path) : RawSource {
 
     private fun open(path: Path): dynamic {
         if (!(fs.existsSync(path.path) as Boolean)) {
-            throw FileNotFoundException("File does not exist: $path")
+            throw FileNotFoundException("File does not exist: ${path.path}")
         }
         val fd = try {
             fs.openSync(path.path, "r")
         } catch (e: Throwable) {
-            throw IOException("Failed to open a file $path.", e)
+            throw IOException("Failed to open a file ${path.path}.", e)
         }
-        if (fd < 0) throw IOException("Failed to open a file $path.")
+        if (fd < 0) throw IOException("Failed to open a file ${path.path}.")
         return fd
     }
 
@@ -116,7 +116,7 @@ internal class FileSource(private val path: Path) : RawSource {
             try {
                 buffer = fs.readFileSync(fd, null)
             } catch (t: Throwable) {
-                throw IOException("Failed to read data from $path", t)
+                throw IOException("Failed to read data from ${path.path}", t)
             }
         }
         val len: Int = buffer.length as Int
@@ -132,8 +132,10 @@ internal class FileSource(private val path: Path) : RawSource {
     }
 
     override fun close() {
-        closed = true
-        fs.closeSync(fd)
+        if (!closed) {
+            closed = true
+            fs.closeSync(fd)
+        }
     }
 }
 
@@ -178,7 +180,9 @@ internal class FileSink(path: Path, append: Boolean) : RawSink {
     override fun flush() = Unit
 
     override fun close() {
-        closed = true
-        fs.closeSync(fd)
+        if (!closed) {
+            closed = true
+            fs.closeSync(fd)
+        }
     }
 }


### PR DESCRIPTION
For JS, unlike other targets, a file was not opened on file sink/source creation. 

For a sink, it was leading to different behavior when the sink was closed without a single byte written to it: on all targets except JS an empty file is created.

For a source, on all targets except JS, an attempt to create a source for a non-existent file is immediately reported as an error, but for JS the error won't be reported until an actual read operation is employed.

This PR aligns JS target's behavior will all other targets.

Fixes #251 