### PR TITLE
Correctly setup toolchain in benchmarks module

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -14,11 +14,11 @@ plugins {
 }
 
 kotlin {
-    jvm {
-        jvmToolchain {
-            languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get()))
-        }
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get()))
     }
+
+    jvm()
 
     sourceSets {
         commonMain {


### PR DESCRIPTION
Current build script will no longer work with K2.