### PR TITLE
Update Dokka to 1.9.20

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "1.9.22"
 java = "8"
-dokka = "1.9.10"
+dokka = "1.9.20"
 kover = "0.7.5"
 bcv = "0.13.2"
 benchmark = "0.4.10"


### PR DESCRIPTION
No issues found comparing to 1.9.10