### PR TITLE
Replace stat call with NSFileManager API on Apple target

### DIFF
--- a/core/apple/src/files/FileSystemApple.kt
+++ b/core/apple/src/files/FileSystemApple.kt
@@ -11,7 +11,7 @@ import kotlinx.cinterop.cstr
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.toKString
 import kotlinx.io.IOException
-import platform.Foundation.NSTemporaryDirectory
+import platform.Foundation.*
 import platform.posix.*
 
 
@@ -54,4 +54,16 @@ internal actual fun realpathImpl(path: String): String {
     } finally {
         free(res)
     }
+}
+
+internal actual fun metadataOrNullImpl(path: Path): FileMetadata? {
+    val attributes = NSFileManager.defaultManager().fileAttributesAtPath(path.path, traverseLink = true) ?: return null
+    val fileType = attributes[NSFileType] as String
+    val isFile = fileType == NSFileTypeRegular
+    val isDir = fileType == NSFileTypeDirectory
+    return FileMetadata(
+        isRegularFile = isFile,
+        isDirectory = isDir,
+        size = if (isFile) attributes[NSFileSize] as Long else -1
+    )
 }

--- a/core/nonApple/src/files/FileSystemNonApple.kt
+++ b/core/nonApple/src/files/FileSystemNonApple.kt
@@ -5,10 +5,28 @@
 
 package kotlinx.io.files
 
-import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.toKString
-import platform.posix.getenv
+import kotlinx.cinterop.*
+import kotlinx.io.IOException
+import platform.posix.*
 
 @OptIn(ExperimentalForeignApi::class)
 public actual val SystemTemporaryDirectory: Path
     get() = Path(getenv("TMPDIR")?.toKString() ?: getenv("TMP")?.toKString() ?: "")
+
+@OptIn(ExperimentalForeignApi::class, UnsafeNumber::class)
+internal actual fun metadataOrNullImpl(path: Path): FileMetadata? {
+    memScoped {
+        val struct_stat = alloc<stat>()
+        if (stat(path.path, struct_stat.ptr) != 0) {
+            if (errno == ENOENT) return null
+            throw IOException("stat failed to ${path.path}: ${strerror(errno)?.toKString()}")
+        }
+        val mode = struct_stat.st_mode.toInt()
+        val isFile = (mode and S_IFMT) == S_IFREG
+        return FileMetadata(
+            isRegularFile = isFile,
+            isDirectory = (mode and S_IFMT) == S_IFDIR,
+            if (isFile) struct_stat.st_size.toLong() else -1L
+        )
+    }
+}


### PR DESCRIPTION
Starting from May 1, 2024 developers have to explicitly declare why they use APIs allowing to access file timestamps in privacy manifest files; otherwise, an app won't be accepted by the AppStore. 

The only restricted API we're currently using is stat, and since we don't extract any timestamps using it, we can safely replace it with NSFileManager::fileAttributesAtPath.

For more details on the restriction imposed on timestamp-accessing APIs read https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api

Closes #297