### PR TITLE
Move samples and packages configuration of Dokka to convention plugin

### DIFF
--- a/build-logic/src/main/kotlin/kotlinx/io/conventions/kotlinx-io-dokka.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlinx/io/conventions/kotlinx-io-dokka.gradle.kts
@@ -19,5 +19,18 @@ tasks.withType<DokkaTaskPartial>().configureEach {
             remoteUrl.set(URL("https://github.com/kotlin/kotlinx-io/tree/master"))
             remoteLineSuffix.set("#L")
         }
+
+        // we don't want to advertise `unsafe` APIs in documentation
+        perPackageOption {
+            suppress.set(true)
+            matchingRegex.set(".*unsafe.*")
+        }
+
+        // as in kotlinx-io-multiplatform.gradle.kts:configureSourceSet
+        val platform = name.dropLast(4)
+        samples.from(
+            "common/test/samples",
+            "$platform/test/samples"
+        )
     }
 }

--- a/bytestring/build.gradle.kts
+++ b/bytestring/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.dokka.gradle.DokkaTaskPartial
-
 plugins {
     id("kotlinx-io-multiplatform")
     id("kotlinx-io-publish")
@@ -24,17 +22,5 @@ kotlin {
                 }
             }
         }
-    }
-}
-
-
-tasks.withType<DokkaTaskPartial>().configureEach {
-    dokkaSourceSets.configureEach {
-        perPackageOption {
-            suppress.set(true)
-            matchingRegex.set(".*unsafe.*")
-        }
-
-        samples.from("common/test/samples/samples.kt")
     }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -4,7 +4,6 @@
  */
 
 import org.gradle.internal.os.OperatingSystem
-import org.jetbrains.dokka.gradle.DokkaTaskPartial
 
 plugins {
     id("kotlinx-io-multiplatform")
@@ -50,20 +49,6 @@ kotlin {
         appleTest.dependencies {
             implementation(libs.kotlinx.coroutines.core)
         }
-    }
-}
-
-tasks.withType<DokkaTaskPartial>().configureEach {
-    dokkaSourceSets.configureEach {
-        samples.from(
-            "common/test/samples/rawSinkSample.kt",
-            "common/test/samples/rawSourceSample.kt",
-            "common/test/samples/moduleDescriptionSample.kt",
-            "common/test/samples/samples.kt",
-            "common/test/samples/byteStringSample.kt",
-            "jvm/test/samples/samplesJvm.kt",
-            "apple/test/samples/samplesApple.kt"
-        )
     }
 }
 


### PR DESCRIPTION
Fixes #210

Note: I've also moved `unsafe` package hiding to convention plugin, because AFAIU the same idea of not advertising of this API in official documentation will be applied to `unsafe` APIs in `core`.