### PR TITLE
Add UnknownServiceException

### DIFF
--- a/core/common/src/-CommonPlatform.kt
+++ b/core/common/src/-CommonPlatform.kt
@@ -39,6 +39,11 @@ public expect open class EOFException : IOException {
     public constructor(message: String?)
 }
 
+public expect open class UnknownServiceException : IOException {
+    public constructor()
+    public constructor(message: String?)
+}
+
 
 // There is no actual AutoCloseable on JVM (https://youtrack.jetbrains.com/issue/KT-55777),
 // but on JVM we have to explicitly implement by RawSink and the compiler does not allow that.

--- a/core/js/src/-PlatformJs.kt
+++ b/core/js/src/-PlatformJs.kt
@@ -21,6 +21,12 @@ public actual open class EOFException : IOException {
     public actual constructor(message: String?) : super(message)
 }
 
+public actual open class UnknownServiceException : IOException {
+    public actual constructor() : super()
+
+    public actual constructor(message: String?) : super(message)
+}
+
 internal actual fun withCaughtException(block: () -> Unit): Throwable? {
     try {
         block()

--- a/core/jvm/src/-JvmPlatform.kt
+++ b/core/jvm/src/-JvmPlatform.kt
@@ -24,3 +24,5 @@ package kotlinx.io
 public actual typealias IOException = java.io.IOException
 
 public actual typealias EOFException = java.io.EOFException
+
+public actual typealias UnknownServiceException = java.net.UnknownServiceException

--- a/core/native/src/-NonJvmPlatform.kt
+++ b/core/native/src/-NonJvmPlatform.kt
@@ -35,3 +35,9 @@ public actual open class EOFException : IOException {
 
     public actual constructor(message: String?) : super(message)
 }
+
+public actual open class UnknownServiceException : IOException {
+    public actual constructor() : super()
+
+    public actual constructor(message: String?) : super(message)
+}

--- a/core/wasm/src/-PlatformWasm.kt
+++ b/core/wasm/src/-PlatformWasm.kt
@@ -20,3 +20,9 @@ public actual open class EOFException : IOException {
 
     public actual constructor(message: String?) : super(message)
 }
+
+public actual open class UnknownServiceException : IOException {
+    public actual constructor() : super()
+
+    public actual constructor(message: String?) : super(message)
+}


### PR DESCRIPTION
I noticed Kotr is migrating to kotlinx-io in https://github.com/ktorio/ktor/pull/4032, and I sent a PR https://github.com/ktorio/ktor/pull/3725 which is depending on `UnknownServiceException`, it would be awesome to port this exception for all platforms to get rid of custom implementations in Ktor.