### PR TITLE
[PR 4/5] Rewrite existing extensions using unsafe API

### DIFF
--- a/core/apple/src/BuffersApple.kt
+++ b/core/apple/src/BuffersApple.kt
@@ -8,51 +8,48 @@
 package kotlinx.io
 
 import kotlinx.cinterop.*
+import kotlinx.io.unsafe.UnsafeBufferOperations
+import kotlinx.io.unsafe.withData
 import platform.Foundation.NSData
 import platform.Foundation.create
 import platform.Foundation.data
 import platform.darwin.NSUIntegerMax
 import platform.posix.*
 
-@OptIn(ExperimentalForeignApi::class)
+@OptIn(ExperimentalForeignApi::class, UnsafeIoApi::class)
 internal fun Buffer.write(source: CPointer<uint8_tVar>, maxLength: Int) {
     require(maxLength >= 0) { "maxLength ($maxLength) must not be negative" }
 
     var currentOffset = 0
     while (currentOffset < maxLength) {
-        val tail = writableSegment(1)
-
-        val toCopy = minOf(maxLength - currentOffset, Segment.SIZE - tail.limit)
-        tail.data.usePinned {
-            memcpy(it.addressOf(tail.limit), source + currentOffset, toCopy.convert())
+        UnsafeBufferOperations.writeToTail(this, 1) { data, pos, limit ->
+            val toCopy = minOf(maxLength - currentOffset, limit - pos)
+            data.usePinned {
+                memcpy(it.addressOf(pos), source + currentOffset, toCopy.convert())
+            }
+            currentOffset += toCopy
+            toCopy
         }
-
-        currentOffset += toCopy
-        tail.limit += toCopy
     }
-    this.sizeMut += maxLength
 }
 
+@OptIn(UnsafeIoApi::class)
 internal fun Buffer.readAtMostTo(sink: CPointer<uint8_tVar>, maxLength: Int): Int {
     require(maxLength >= 0) { "maxLength ($maxLength) must not be negative" }
 
-    val s = head ?: return 0
-    val toCopy = minOf(maxLength, s.limit - s.pos)
-    s.data.usePinned {
-        memcpy(sink, it.addressOf(s.pos), toCopy.convert())
-    }
-
-    s.pos += toCopy
-    this.sizeMut -= toCopy.toLong()
-
-    if (s.pos == s.limit) {
-        recycleHead()
+    var toCopy = 0
+    UnsafeBufferOperations.readFromHead(this) { data, pos, limit ->
+        toCopy = minOf(maxLength, limit - pos)
+        data.usePinned {
+            memcpy(sink, it.addressOf(pos), toCopy.convert())
+        }
+        toCopy
     }
 
     return toCopy
 }
 
-@OptIn(BetaInteropApi::class)
+@OptIn(BetaInteropApi::class, UnsafeIoApi::class)
 internal fun Buffer.snapshotAsNSData(): NSData {
     if (size == 0L) return NSData.data()
 
@@ -60,17 +57,21 @@ internal fun Buffer.snapshotAsNSData(): NSData {
 
     val bytes = malloc(size.convert())?.reinterpret<uint8_tVar>()
         ?: throw Error("malloc failed: ${strerror(errno)?.toKString()}")
-    var curr = head
-    var index = 0
-    do {
-        check(curr != null) { "Current segment is null" }
-        val pos = curr.pos
-        val length = curr.limit - pos
-        curr.data.usePinned {
-            memcpy(bytes + index, it.addressOf(pos), length.convert())
+
+    UnsafeBufferOperations.iterate(this) { ctx, head ->
+        var curr: Segment? = head
+        var index = 0
+        while (curr != null) {
+            val segment: Segment = curr
+            ctx.withData(segment) { data, pos, limit ->
+                val length = limit - pos
+                data.usePinned {
+                    memcpy(bytes + index, it.addressOf(pos), length.convert())
+                }
+                index += length
+            }
+            curr = ctx.next(segment)
         }
-        curr = curr.next
-        index += length
-    } while (curr != null)
+    }
     return NSData.create(bytesNoCopy = bytes, length = size.convert())
 }

--- a/core/common/src/Buffer.kt
+++ b/core/common/src/Buffer.kt
@@ -291,6 +291,9 @@ public class Buffer : Source, Sink {
         if (position < 0 || position >= size) {
             throw IndexOutOfBoundsException("position ($position) is not within the range [0..size($size))")
         }
+        if (position == 0L) {
+            return head!!.getUnchecked(0)
+        }
         seek(position) { s, offset ->
             return s!!.data[(s.pos + position - offset).toInt()]
         }

--- a/core/common/src/Buffers.kt
+++ b/core/common/src/Buffers.kt
@@ -22,7 +22,9 @@ public fun Buffer.snapshot(): ByteString {
         var curr = head
         do {
             check(curr != null) { "Current segment is null" }
-            append(curr.data, curr.pos, curr.limit)
+            for (idx in 0 until curr.size) {
+                append(curr.getUnchecked(idx))
+            }
             curr = curr.next
         } while (curr != null)
     }

--- a/core/common/src/ByteStrings.kt
+++ b/core/common/src/ByteStrings.kt
@@ -9,6 +9,7 @@ import kotlinx.io.bytestring.ByteString
 import kotlinx.io.bytestring.isEmpty
 import kotlinx.io.bytestring.unsafe.UnsafeByteStringApi
 import kotlinx.io.bytestring.unsafe.UnsafeByteStringOperations
+import kotlinx.io.unsafe.UnsafeBufferOperations
 import kotlin.math.min
 
 /**
@@ -24,7 +25,7 @@ import kotlin.math.min
  *
  * @sample kotlinx.io.samples.ByteStringSamples.writeByteString
  */
-@OptIn(DelicateIoApi::class)
+@OptIn(DelicateIoApi::class, UnsafeByteStringApi::class, UnsafeIoApi::class)
 public fun Sink.write(byteString: ByteString, startIndex: Int = 0, endIndex: Int = byteString.size) {
     checkBounds(byteString.size, startIndex, endIndex)
     if (endIndex == startIndex) {
@@ -33,21 +34,17 @@ public fun Sink.write(byteString: ByteString, startIndex: Int = 0, endIndex: Int
 
     writeToInternalBuffer { buffer ->
         var offset = startIndex
-        val tail = buffer.head?.prev
-        if (tail != null) {
-            val bytesToWrite = min(tail.data.size - tail.limit, endIndex - offset)
-            byteString.copyInto(tail.data, tail.limit, offset, offset + bytesToWrite)
-            offset += bytesToWrite
-            tail.limit += bytesToWrite
-            buffer.sizeMut += bytesToWrite
-        }
-        while (offset < endIndex) {
-            val bytesToWrite = min(endIndex - offset, Segment.SIZE)
-            val seg = buffer.writableSegment(bytesToWrite)
-            byteString.copyInto(seg.data, seg.limit, offset, offset + bytesToWrite)
-            seg.limit += bytesToWrite
-            buffer.sizeMut += bytesToWrite
-            offset += bytesToWrite
+
+        UnsafeByteStringOperations.withByteArrayUnsafe(byteString) { data ->
+            while (offset < endIndex) {
+                var written = 0
+                UnsafeBufferOperations.writeToTail(buffer, 1) { segData, pos, limit ->
+                    written = min(endIndex - offset, limit - pos)
+                    data.copyInto(segData, pos, offset, offset + written)
+                    written
+                }
+                offset += written
+            }
         }
     }
 }

--- a/core/common/src/Sinks.kt
+++ b/core/common/src/Sinks.kt
@@ -8,6 +8,7 @@ package kotlinx.io
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind.EXACTLY_ONCE
 import kotlin.contracts.contract
+import kotlinx.io.unsafe.UnsafeBufferOperations
 
 private val HEX_DIGIT_BYTES = ByteArray(16) {
     ((if (it < 10) '0'.code else ('a'.code - 10)) + it).toByte()
@@ -63,7 +64,7 @@ public fun Sink.writeLongLe(long: Long) {
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeDecimalLong
  */
-@OptIn(DelicateIoApi::class)
+@OptIn(DelicateIoApi::class, UnsafeIoApi::class)
 public fun Sink.writeDecimalLong(long: Long) {
     var v = long
     if (v == 0L) {
@@ -116,20 +117,17 @@ public fun Sink.writeDecimalLong(long: Long) {
     }
 
     writeToInternalBuffer { buffer ->
-        val tail = buffer.writableSegment(width)
-        val data = tail.data
-        var pos = tail.limit + width // We write backwards from right to left.
-        while (v != 0L) {
-            val digit = (v % 10).toInt()
-            data[--pos] = HEX_DIGIT_BYTES[digit]
-            v /= 10
+        UnsafeBufferOperations.writeToTail(buffer, width) { ctx, segment ->
+            for (pos in width - 1 downTo if (negative) 1 else 0) {
+                val digit = (v % 10).toByte()
+                ctx.setUnchecked(segment, pos, HEX_DIGIT_BYTES[digit.toInt()])
+                v /= 10
+            }
+            if (negative) {
+                ctx.setUnchecked(segment, 0, '-'.code.toByte())
+            }
+            width
         }
-        if (negative) {
-            data[--pos] = '-'.code.toByte()
-        }
-
-        tail.limit += width
-        buffer.sizeMut += width.toLong()
     }
 }
 
@@ -144,7 +142,7 @@ public fun Sink.writeDecimalLong(long: Long) {
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeHexLong
  */
-@OptIn(DelicateIoApi::class)
+@OptIn(DelicateIoApi::class, UnsafeIoApi::class)
 public fun Sink.writeHexadecimalUnsignedLong(long: Long) {
     var v = long
     if (v == 0L) {
@@ -156,17 +154,13 @@ public fun Sink.writeHexadecimalUnsignedLong(long: Long) {
     val width = hexNumberLength(v)
 
     writeToInternalBuffer { buffer ->
-        val tail = buffer.writableSegment(width)
-        val data = tail.data
-        var pos = tail.limit + width - 1
-        val start = tail.limit
-        while (pos >= start) {
-            data[pos] = HEX_DIGIT_BYTES[(v and 0xF).toInt()]
-            v = v ushr 4
-            pos--
+        UnsafeBufferOperations.writeToTail(buffer, width) { ctx, segment ->
+            for (pos in width - 1 downTo 0) {
+                ctx.setUnchecked(segment, pos, HEX_DIGIT_BYTES[v.toInt().and(0xF)])
+                v = v ushr 4
+            }
+            width
         }
-        tail.limit += width
-        buffer.sizeMut += width.toLong()
     }
 }
 

--- a/core/common/src/unsafe/UnsafeBufferOperations.kt
+++ b/core/common/src/unsafe/UnsafeBufferOperations.kt
@@ -254,12 +254,11 @@ public object UnsafeBufferOperations {
     public inline fun writeToTail(
         buffer: Buffer,
         minimumCapacity: Int,
-        writeAction: (SegmentWriteContext, Segment) -> Int
+        writeAction: (context: SegmentWriteContext, tail: Segment) -> Int
     ): Int {
         contract {
             callsInPlace(writeAction, EXACTLY_ONCE)
         }
-
         val tail = buffer.writableSegment(minimumCapacity)
         val bytesWritten = writeAction(SegmentWriteContextImpl, tail)
 
@@ -304,7 +303,10 @@ public object UnsafeBufferOperations {
      * @sample kotlinx.io.samples.unsafe.UnsafeReadWriteSamplesJvm.messageDigest
      * @sample kotlinx.io.samples.unsafe.UnsafeBufferOperationsSamples.crc32Unsafe
      */
-    public inline fun iterate(buffer: Buffer, iterationAction: (BufferIterationContext, Segment?) -> Unit) {
+    public inline fun iterate(
+        buffer: Buffer,
+        iterationAction: (context: BufferIterationContext, head: Segment?) -> Unit
+    ) {
         contract {
             callsInPlace(iterationAction, EXACTLY_ONCE)
         }
@@ -335,7 +337,7 @@ public object UnsafeBufferOperations {
      */
     public inline fun iterate(
         buffer: Buffer, offset: Long,
-        iterationAction: (BufferIterationContext, Segment?, Long) -> Unit
+        iterationAction: (context: BufferIterationContext, segment: Segment?, startOfTheSegmentOffset: Long) -> Unit
     ) {
         contract {
             callsInPlace(iterationAction, EXACTLY_ONCE)
@@ -393,7 +395,10 @@ public interface SegmentReadContext {
 @UnsafeIoApi
 @JvmSynthetic
 @OptIn(ExperimentalContracts::class)
-public inline fun SegmentReadContext.withData(segment: Segment, readAction: (ByteArray, Int, Int) -> Unit) {
+public inline fun SegmentReadContext.withData(
+    segment: Segment,
+    readAction: (bytes: ByteArray, startIndexInclusive: Int, endIndexExclusive: Int) -> Unit
+) {
     contract {
         callsInPlace(readAction, EXACTLY_ONCE)
     }

--- a/core/jvm/src/BuffersJvm.kt
+++ b/core/jvm/src/BuffersJvm.kt
@@ -20,6 +20,8 @@
  */
 package kotlinx.io
 
+import kotlinx.io.unsafe.UnsafeBufferOperations
+import kotlinx.io.unsafe.withData
 import java.io.EOFException
 import java.io.IOException
 import java.io.InputStream
@@ -57,23 +59,25 @@ public fun Buffer.write(input: InputStream, byteCount: Long): Buffer {
     return this
 }
 
+@OptIn(UnsafeIoApi::class)
 private fun Buffer.write(input: InputStream, byteCount: Long, forever: Boolean) {
     var remainingByteCount = byteCount
-    while (remainingByteCount > 0L || forever) {
-        val tail = writableSegment(1)
-        val maxToCopy = minOf(remainingByteCount, Segment.SIZE - tail.limit).toInt()
-        val bytesRead = input.read(tail.data, tail.limit, maxToCopy)
-        if (bytesRead == -1) {
-            if (tail.pos == tail.limit) {
-                // We allocated a tail segment, but didn't end up needing it. Recycle!
-                recycleTail()
+    var exchaused = false
+    while (!exchaused && (remainingByteCount > 0L || forever)) {
+        UnsafeBufferOperations.writeToTail(this, 1) { data, pos, limit ->
+            val maxToCopy = minOf(remainingByteCount, limit - pos).toInt()
+            val bytesRead = input.read(data, pos, maxToCopy)
+            if (bytesRead == -1) {
+                if (!forever) {
+                    throw EOFException("Stream exhausted before $byteCount bytes were read.")
+                }
+                exchaused = true
+                0
+            } else {
+                remainingByteCount -= bytesRead
+                bytesRead
             }
-            if (forever) return
-            throw EOFException("Stream exhausted before $byteCount bytes were read.")
         }
-        tail.limit += bytesRead
-        sizeMut += bytesRead.toLong()
-        remainingByteCount -= bytesRead.toLong()
     }
 }
 
@@ -87,22 +91,17 @@ private fun Buffer.write(input: InputStream, byteCount: Long, forever: Boolean) 
  *
  * @sample kotlinx.io.samples.KotlinxIoSamplesJvm.bufferTransferToStream
  */
+@OptIn(UnsafeIoApi::class)
 public fun Buffer.readTo(out: OutputStream, byteCount: Long = size) {
     checkOffsetAndCount(size, 0, byteCount)
     var remainingByteCount = byteCount
 
-    var s = head
     while (remainingByteCount > 0L) {
-        val toCopy = minOf(remainingByteCount, s!!.limit - s.pos).toInt()
-        out.write(s.data, s.pos, toCopy)
-
-        s.pos += toCopy
-        sizeMut -= toCopy.toLong()
-        remainingByteCount -= toCopy.toLong()
-
-        if (s.pos == s.limit) {
-            recycleHead()
-            s = head
+        UnsafeBufferOperations.readFromHead(this) { data, pos, limit ->
+            val toCopy = minOf(remainingByteCount, limit - pos).toInt()
+            out.write(data, pos, toCopy)
+            remainingByteCount -= toCopy
+            toCopy
         }
     }
 }
@@ -120,6 +119,7 @@ public fun Buffer.readTo(out: OutputStream, byteCount: Long = size) {
  *
  * @sample kotlinx.io.samples.KotlinxIoSamplesJvm.copyBufferToOutputStream
  */
+@OptIn(UnsafeIoApi::class)
 public fun Buffer.copyTo(
     out: OutputStream,
     startIndex: Long = 0L,
@@ -128,24 +128,20 @@ public fun Buffer.copyTo(
     checkBounds(size, startIndex, endIndex)
     if (startIndex == endIndex) return
 
-    var currentOffset = startIndex
     var remainingByteCount = endIndex - startIndex
 
-    // Skip segments that we aren't copying from.
-    var s = head
-    while (currentOffset >= s!!.limit - s.pos) {
-        currentOffset -= (s.limit - s.pos).toLong()
-        s = s.next
-    }
-
-    // Copy from one segment at a time.
-    while (remainingByteCount > 0L) {
-        val pos = (s!!.pos + currentOffset).toInt()
-        val toCopy = minOf(s.limit - pos, remainingByteCount).toInt()
-        out.write(s.data, pos, toCopy)
-        remainingByteCount -= toCopy.toLong()
-        currentOffset = 0L
-        s = s.next
+    UnsafeBufferOperations.iterate(this, startIndex) { ctx, seg, segOffset ->
+        var curr = seg!!
+        var currentOffset = (startIndex - segOffset).toInt()
+        while (remainingByteCount > 0) {
+            ctx.withData(curr) { data, pos, limit ->
+                val toCopy = minOf(limit - pos - currentOffset, remainingByteCount).toInt()
+                out.write(data, pos + currentOffset, toCopy)
+                remainingByteCount -= toCopy
+            }
+            curr = ctx.next(curr) ?: break
+            currentOffset = 0
+        }
     }
 }
 
@@ -157,17 +153,14 @@ public fun Buffer.copyTo(
  *
  * @sample kotlinx.io.samples.KotlinxIoSamplesJvm.readWriteByteBuffer
  */
+@OptIn(UnsafeIoApi::class)
 public fun Buffer.readAtMostTo(sink: ByteBuffer): Int {
-    val s = head ?: return -1
-
-    val toCopy = minOf(sink.remaining(), s.limit - s.pos)
-    sink.put(s.data, s.pos, toCopy)
-
-    s.pos += toCopy
-    sizeMut -= toCopy.toLong()
-
-    if (s.pos == s.limit) {
-        recycleHead()
+    if (exhausted()) return -1
+    var toCopy = 0
+    UnsafeBufferOperations.readFromHead(this) { data, pos, limit ->
+        toCopy = minOf(sink.remaining(), limit - pos)
+        sink.put(data, pos, toCopy)
+        toCopy
     }
 
     return toCopy
@@ -178,20 +171,20 @@ public fun Buffer.readAtMostTo(sink: ByteBuffer): Int {
  *
  * @sample kotlinx.io.samples.KotlinxIoSamplesJvm.transferBufferFromByteBuffer
  */
+@OptIn(UnsafeIoApi::class)
 public fun Buffer.transferFrom(source: ByteBuffer): Buffer {
     val byteCount = source.remaining()
     var remaining = byteCount
+
     while (remaining > 0) {
-        val tail = writableSegment(1)
-
-        val toCopy = minOf(remaining, Segment.SIZE - tail.limit)
-        source.get(tail.data, tail.limit, toCopy)
-
-        remaining -= toCopy
-        tail.limit += toCopy
+        UnsafeBufferOperations.writeToTail(this, 1) { data, pos, limit ->
+            val toCopy = minOf(remaining, limit - pos)
+            source.get(data, pos, toCopy)
+            remaining -= toCopy
+            toCopy
+        }
     }
 
-    sizeMut += byteCount.toLong()
     return this
 }
 

--- a/core/jvm/src/SourcesJvm.kt
+++ b/core/jvm/src/SourcesJvm.kt
@@ -20,12 +20,14 @@
  */
 package kotlinx.io
 
+import kotlinx.io.unsafe.UnsafeBufferOperations
 import java.io.EOFException
 import java.io.InputStream
 import java.nio.ByteBuffer
 import java.nio.channels.ReadableByteChannel
 import java.nio.charset.Charset
 
+@OptIn(UnsafeIoApi::class)
 private fun Buffer.readStringImpl(byteCount: Long, charset: Charset): String {
     require(byteCount >= 0 && byteCount <= Int.MAX_VALUE) {
         "byteCount ($byteCount) is not within the range [0..${Int.MAX_VALUE})"
@@ -35,21 +37,21 @@ private fun Buffer.readStringImpl(byteCount: Long, charset: Charset): String {
     }
     if (byteCount == 0L) return ""
 
-    val s = head!!
-    if (s.pos + byteCount > s.limit) {
-        // If the string spans multiple segments, delegate to readBytes().
-        return String(readByteArray(byteCount.toInt()), charset)
+    var result: String? = null
+    UnsafeBufferOperations.readFromHead(this) { data, pos, limit ->
+        val len = limit - pos
+        if (len >= byteCount) {
+            result = String(data, pos, byteCount.toInt(), charset)
+            byteCount.toInt()
+        } else {
+            0
+        }
     }
-
-    val result = String(s.data, s.pos, byteCount.toInt(), charset)
-    s.pos += byteCount.toInt()
-    sizeMut -= byteCount
-
-    if (s.pos == s.limit) {
-        recycleHead()
+    return if (result == null) {
+        String(readByteArray(byteCount.toInt()), charset)
+    } else {
+        result!!
     }
-
-    return result
 }
 
 /**


### PR DESCRIPTION
This PR reimplements existing extensions to use unsafe API introduced in #334 and #336.

In the next patch, Segment's `data` field will be encapsulated.

Related to #135 