### PR TITLE
Avoid unnecessary checks when calling readCodePointValue on Buffer

### DIFF
--- a/core/common/src/Utf8.kt
+++ b/core/common/src/Utf8.kt
@@ -260,6 +260,9 @@ public fun Source.readString(byteCount: Long): String {
  */
 @OptIn(InternalIoApi::class)
 public fun Source.readCodePointValue(): Int {
+    if (this is Buffer) {
+        return commonReadUtf8CodePoint()
+    }
     require(1)
 
     val b0 = buffer[0].toInt()


### PR DESCRIPTION
Improves `readCodePointValue` performance by ~10% when the receiver is `Buffer`.

Addresses a particular issue uncovered in https://github.com/Kotlin/kotlinx.serialization/pull/2707.

In general, similar issues will be tracked by https://github.com/Kotlin/kotlinx-io/issues/342.


Benchmarking results w/ jdk21 on macOS host w/ AS M2 Pro CPU:
- before:
```
Benchmark                                                (encoding)  (minGap)   Mode  Cnt          Score         Error  Units
Utf8CodePointsBenchmark.benchmark                             ascii       128  thrpt    5  140373273.339 ±  694216.983  ops/s
Utf8CodePointsBenchmark.benchmark                              utf8       128  thrpt    5   87815553.220 ± 1128003.103  ops/s
Utf8CodePointsBenchmark.benchmark                            sparse       128  thrpt    5  127022106.163 ± 2328819.676  ops/s
Utf8CodePointsBenchmark.benchmark                            2bytes       128  thrpt    5  114376689.982 ± 1040653.731  ops/s
Utf8CodePointsBenchmark.benchmark                            3bytes       128  thrpt    5   97996115.414 ±  943350.071  ops/s
Utf8CodePointsBenchmark.benchmark                            4bytes       128  thrpt    5   90219791.071 ± 1057392.878  ops/s
Utf8CodePointsBenchmark.benchmark                               bad       128  thrpt    5  129320612.342 ± 1542655.859  ops/s
```

- after:
```
Benchmark                                                (encoding)  (minGap)   Mode  Cnt          Score         Error  Units
Utf8CodePointsBenchmark.benchmark                             ascii       128  thrpt    5  141722288.764 ± 1297310.006  ops/s
Utf8CodePointsBenchmark.benchmark                              utf8       128  thrpt    5   96539014.741 ±  397371.538  ops/s
Utf8CodePointsBenchmark.benchmark                            sparse       128  thrpt    5  136350281.578 ± 9488253.150  ops/s
Utf8CodePointsBenchmark.benchmark                            2bytes       128  thrpt    5  126114440.572 ± 2201911.847  ops/s
Utf8CodePointsBenchmark.benchmark                            3bytes       128  thrpt    5  110880125.804 ± 1953517.672  ops/s
Utf8CodePointsBenchmark.benchmark                            4bytes       128  thrpt    5  101067180.434 ± 1928563.268  ops/s
Utf8CodePointsBenchmark.benchmark                               bad       128  thrpt    5  146300685.623 ± 2768473.597  ops/s
```