### PR TITLE
Track precise number of shared segment copies to return the last one into a segment pool

### DIFF
--- a/core/api/kotlinx-io-core.api
+++ b/core/api/kotlinx-io-core.api
@@ -101,7 +101,8 @@ public abstract interface class kotlinx/io/RawSource : java/lang/AutoCloseable {
 }
 
 public final class kotlinx/io/Segment {
-	public synthetic fun <init> ([BIIZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lkotlinx/io/SegmentCopyTracker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> ([BIILkotlinx/io/SegmentCopyTracker;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final synthetic fun dataAsByteArray (Z)[B
 	public final synthetic fun getLimit ()I
 	public final synthetic fun getNext ()Lkotlinx/io/Segment;

--- a/core/common/src/unsafe/UnsafeBufferOperations.kt
+++ b/core/common/src/unsafe/UnsafeBufferOperations.kt
@@ -37,7 +37,8 @@ public object UnsafeBufferOperations {
     public fun moveToTail(buffer: Buffer, bytes: ByteArray, startIndex: Int = 0, endIndex: Int = bytes.size) {
         checkBounds(bytes.size, startIndex, endIndex)
         val segment = Segment.new(
-            bytes, startIndex, endIndex, shared = true /* to prevent recycling */,
+            bytes, startIndex, endIndex,
+            SimpleCopyTracker().also { it.addCopy() } /* to prevent recycling */,
             owner = false /* can't append to it */
         )
         val tail = buffer.tail

--- a/core/common/test/SimpleCopyTrackerTest.kt
+++ b/core/common/test/SimpleCopyTrackerTest.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.io
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SimpleCopyTrackerTest {
+    @Test
+    fun stateTransition() {
+        val tracker = SimpleCopyTracker()
+        assertFalse(tracker.shared)
+
+        assertFalse(tracker.removeCopyIfShared())
+        assertFalse(tracker.shared)
+
+        tracker.addCopy()
+        assertTrue(tracker.shared)
+
+        assertTrue(tracker.removeCopyIfShared())
+        assertTrue(tracker.shared)
+    }
+}

--- a/core/js/src/SegmentPool.kt
+++ b/core/js/src/SegmentPool.kt
@@ -10,7 +10,7 @@ internal actual object SegmentPool {
 
     actual val byteCount: Int = 0
 
-    actual fun take(): Segment = Segment.new()
+    actual fun take(): Segment = Segment.new(SimpleCopyTracker())
 
     actual fun recycle(segment: Segment) {
     }

--- a/core/jvm/test/PoolingTest.kt
+++ b/core/jvm/test/PoolingTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.io
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class PoolingTest {
+    @Test
+    fun segmentSharing() {
+        val buffer = Buffer()
+
+        buffer.writeByte(1)
+        var poolSize = SegmentPool.byteCount
+        buffer.clear()
+        // clear should return a segment to a pool, so the pool size should grow
+        assertTrue(poolSize < SegmentPool.byteCount)
+
+        buffer.writeByte(1)
+        poolSize = SegmentPool.byteCount
+        val copy = buffer.copy()
+        buffer.clear()
+        copy.clear()
+        assertTrue(poolSize < SegmentPool.byteCount)
+
+        buffer.writeByte(1)
+        poolSize = SegmentPool.byteCount
+        val peek = buffer.peek().buffered()
+        peek.readByte()
+        buffer.clear()
+        assertTrue(poolSize < SegmentPool.byteCount)
+    }
+}

--- a/core/jvm/test/RefCounteringCopyTrackerTest.kt
+++ b/core/jvm/test/RefCounteringCopyTrackerTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.io
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RefCounteringCopyTrackerTest {
+    @Test
+    fun stateTransition() {
+        val tracker = RefCountingCopyTracker()
+        assertFalse(tracker.shared)
+
+        assertFalse(tracker.removeCopyIfShared())
+        assertFalse(tracker.shared)
+
+        tracker.addCopy()
+        assertTrue(tracker.shared)
+        assertTrue(tracker.removeCopyIfShared())
+        assertFalse(tracker.shared)
+
+        tracker.addCopy()
+        assertTrue(tracker.shared)
+        tracker.addCopy()
+        assertTrue(tracker.shared)
+        assertTrue(tracker.removeCopyIfShared())
+        assertTrue(tracker.shared)
+        assertTrue(tracker.removeCopyIfShared())
+        assertFalse(tracker.shared)
+    }
+}

--- a/core/native/src/SegmentPool.kt
+++ b/core/native/src/SegmentPool.kt
@@ -25,7 +25,7 @@ internal actual object SegmentPool {
 
     actual val byteCount: Int = 0
 
-    actual fun take(): Segment = Segment.new()
+    actual fun take(): Segment = Segment.new(SimpleCopyTracker())
 
     actual fun recycle(segment: Segment) {
     }

--- a/core/wasm/src/SegmentPool.kt
+++ b/core/wasm/src/SegmentPool.kt
@@ -10,7 +10,7 @@ internal actual object SegmentPool {
 
     actual val byteCount: Int = 0
 
-    actual fun take(): Segment = Segment.new()
+    actual fun take(): Segment = Segment.new(SimpleCopyTracker())
 
     actual fun recycle(segment: Segment) {
     }


### PR DESCRIPTION
There are two really nice Okio features kotlinx-io inherited:
- copying buffers is cheap, thanks to segment cloning/sharing;
- adding a new segment to a buffer on JVM is also cheap, thanks to segment pooling.

Unfortunately, these two features don't work well together: once a segment is shared (and that is happening not only on explicit buffer copying but also in less obvious scenarios, like using the `PeekSource`), it will never be returned into a pool.

The main cause is that the current "shared" state is tracked by a flag. It's easy to transfer from an unshared to a shared state, but there's no way back.

To address that issue, the shared state should be tracked using reference counting.
Obviously, such precision comes with a price, but state transitions and its checks are not that common, so it should be almost transparent performance-wise.