### PR TITLE
Specify IOException among other exception that could be thrown by I/O function calls

### DIFF
--- a/core/common/src/ByteStrings.kt
+++ b/core/common/src/ByteStrings.kt
@@ -21,6 +21,7 @@ import kotlin.math.min
  * @throws IndexOutOfBoundsException when [startIndex] or [endIndex] is out of range of [byteString] indices.
  * @throws IllegalArgumentException when `startIndex > endIndex`.
  * @throws IllegalStateException if the sink is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.ByteStringSamples.writeByteString
  */
@@ -56,6 +57,7 @@ public fun Sink.write(byteString: ByteString, startIndex: Int = 0, endIndex: Int
  * Consumes all bytes from this source and wraps it into a byte string.
  *
  * @throws IllegalStateException if the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.ByteStringSamples.readByteString
  */
@@ -72,6 +74,7 @@ public fun Source.readByteString(): ByteString {
  * @throws EOFException when the source is exhausted before reading [byteCount] bytes from it.
  * @throws IllegalArgumentException when [byteCount] is negative.
  * @throws IllegalStateException if the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.ByteStringSamples.readByteString
  */
@@ -90,6 +93,7 @@ public fun Source.readByteString(byteCount: Int): ByteString {
  *
  * @throws IllegalArgumentException if [startIndex] is negative.
  * @throws IllegalStateException if the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.ByteStringSamples.indexOfByteString
  */

--- a/core/common/src/RawSink.kt
+++ b/core/common/src/RawSink.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 JetBrains s.r.o. and respective authors and developers.
+ * Copyright 2017-2024 JetBrains s.r.o. and respective authors and developers.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENCE file.
  */
 
@@ -43,6 +43,7 @@ public expect interface RawSink : AutoCloseable {
      *
      * @throws IllegalArgumentException when the [source]'s size is below [byteCount] or [byteCount] is negative.
      * @throws IllegalStateException when the sink is closed.
+     * @throws IOException when some I/O error occurs.
      */
     public fun write(source: Buffer, byteCount: Long)
 
@@ -50,12 +51,15 @@ public expect interface RawSink : AutoCloseable {
      * Pushes all buffered bytes to their final destination.
      *
      * @throws IllegalStateException when the sink is closed.
+     * @throws IOException when some I/O error occurs.
      */
     public fun flush()
 
     /**
      * Pushes all buffered bytes to their final destination and releases the resources held by this
      * sink. It is an error to write a closed sink. It is safe to close a sink more than once.
+     *
+     * @throws IOException when some I/O error occurs.
      */
     override fun close()
 }

--- a/core/common/src/RawSource.kt
+++ b/core/common/src/RawSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 JetBrains s.r.o. and respective authors and developers.
+ * Copyright 2017-2024 JetBrains s.r.o. and respective authors and developers.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENCE file.
  */
 
@@ -44,6 +44,7 @@ public interface RawSource : AutoCloseable {
      *
      * @throws IllegalArgumentException when [byteCount] is negative.
      * @throws IllegalStateException when the source is closed.
+     * @throws IOException when some I/O error occurs.
      *
      * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readAtMostToSink
      */
@@ -52,6 +53,8 @@ public interface RawSource : AutoCloseable {
     /**
      * Closes this source and releases the resources held by this source. It is an error to read a
      * closed source. It is safe to close a source more than once.
+     *
+     * @throws IOException when some I/O error occurs.
      */
     override fun close()
 }

--- a/core/common/src/Sink.kt
+++ b/core/common/src/Sink.kt
@@ -76,6 +76,7 @@ public sealed interface Sink : RawSink {
      * @throws IndexOutOfBoundsException when [startIndex] or [endIndex] is out of range of [source] array indices.
      * @throws IllegalArgumentException when `startIndex > endIndex`.
      * @throws IllegalStateException when the sink is closed.
+     * @throws IOException when some I/O error occurs.
      *
      * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeByteArrayToSink
      */
@@ -88,6 +89,7 @@ public sealed interface Sink : RawSink {
      * @param source the source to consume data from.
      *
      * @throws IllegalStateException when the sink or [source] is closed.
+     * @throws IOException when some I/O error occurs.
      *
      * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.transferFrom
      */
@@ -104,6 +106,7 @@ public sealed interface Sink : RawSink {
      *
      * @throws IllegalArgumentException when [byteCount] is negative.
      * @throws IllegalStateException when the sink or [source] is closed.
+     * @throws IOException when some I/O error occurs.
      *
      * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeSourceToSink
      */
@@ -115,6 +118,7 @@ public sealed interface Sink : RawSink {
      * @param byte the byte to be written.
      *
      * @throws IllegalStateException when the sink is closed.
+     * @throws IOException when some I/O error occurs.
      *
      * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeByte
      */
@@ -126,6 +130,7 @@ public sealed interface Sink : RawSink {
      * @param short the short integer to be written.
      *
      * @throws IllegalStateException when the sink is closed.
+     * @throws IOException when some I/O error occurs.
      *
      * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeShort
      */
@@ -137,6 +142,7 @@ public sealed interface Sink : RawSink {
      * @param int the integer to be written.
      *
      * @throws IllegalStateException when the sink is closed.
+     * @throws IOException when some I/O error occurs.
      *
      * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeInt
      */
@@ -148,6 +154,7 @@ public sealed interface Sink : RawSink {
      * @param long the long integer to be written.
      *
      * @throws IllegalStateException when the sink is closed.
+     * @throws IOException when some I/O error occurs.
      *
      * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeLong
      */
@@ -158,6 +165,7 @@ public sealed interface Sink : RawSink {
      * Then the underlying sink is explicitly flushed.
      *
      * @throws IllegalStateException when the sink is closed.
+     * @throws IOException when some I/O error occurs.
      *
      * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.flush
      */
@@ -171,6 +179,7 @@ public sealed interface Sink : RawSink {
      * Call this method before a buffered sink goes out of scope so that its data can reach its destination.
      *
      * @throws IllegalStateException when the sink is closed.
+     * @throws IOException when some I/O error occurs.
      *
      * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.emit
      */
@@ -189,6 +198,7 @@ public sealed interface Sink : RawSink {
      * Consider using [Sink.writeToInternalBuffer] for writes into [buffered] followed by [hintEmit] call.
      *
      * @throws IllegalStateException when the sink is closed.
+     * @throws IOException when some I/O error occurs.
      */
     @InternalIoApi
     public fun hintEmit()

--- a/core/common/src/Sinks.kt
+++ b/core/common/src/Sinks.kt
@@ -15,6 +15,7 @@ private val HEX_DIGIT_BYTES = ByteArray(16) {
  * @param short the short integer to be written.
  *
  * @throws IllegalStateException when the sink is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeShortLe
  */
@@ -28,6 +29,7 @@ public fun Sink.writeShortLe(short: Short) {
  * @param int the integer to be written.
  *
  * @throws IllegalStateException when the sink is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeIntLe
  */
@@ -41,6 +43,7 @@ public fun Sink.writeIntLe(int: Int) {
  * @param long the long integer to be written.
  *
  * @throws IllegalStateException when the sink is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeLongLe
  */
@@ -56,6 +59,7 @@ public fun Sink.writeLongLe(long: Long) {
  * @param long the long to be written.
  *
  * @throws IllegalStateException when the sink is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeDecimalLong
  */
@@ -137,6 +141,7 @@ public fun Sink.writeDecimalLong(long: Long) {
  * @param long the long to be written.
  *
  * @throws IllegalStateException when the sink is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeHexLong
  */
@@ -172,6 +177,7 @@ public fun Sink.writeHexadecimalUnsignedLong(long: Long) {
  * @param byte the byte to be written.
  *
  * @throws IllegalStateException when the sink is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeUByte
  */
@@ -185,6 +191,7 @@ public fun Sink.writeUByte(byte: UByte) {
  * @param short the unsigned short integer to be written.
  *
  * @throws IllegalStateException when the sink is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeUShort
  */
@@ -198,6 +205,7 @@ public fun Sink.writeUShort(short: UShort) {
  * @param int the unsigned integer to be written.
  *
  * @throws IllegalStateException when the sink is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeUInt
  */
@@ -211,6 +219,7 @@ public fun Sink.writeUInt(int: UInt) {
  * @param long the unsigned long integer to be written.
  *
  * @throws IllegalStateException when the sink is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeULong
  */
@@ -224,6 +233,7 @@ public fun Sink.writeULong(long: ULong) {
  * @param short the unsigned short integer to be written.
  *
  * @throws IllegalStateException when the sink is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeUShortLe
  */
@@ -237,6 +247,7 @@ public fun Sink.writeUShortLe(short: UShort) {
  * @param int the unsigned integer to be written.
  *
  * @throws IllegalStateException when the sink is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeUIntLe
  */
@@ -250,6 +261,7 @@ public fun Sink.writeUIntLe(int: UInt) {
  * @param long the unsigned long integer to be written.
  *
  * @throws IllegalStateException when the sink is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeULongLe
  */
@@ -272,6 +284,7 @@ public fun Sink.writeULongLe(long: ULong) {
  * @param float the floating point number to be written.
  *
  * @throws IllegalStateException when the sink is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeFloat
  */
@@ -290,6 +303,7 @@ public fun Sink.writeFloat(float: Float) {
  * @param double the floating point number to be written.
  *
  * @throws IllegalStateException when the sink is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeDouble
  */
@@ -312,6 +326,7 @@ public fun Sink.writeDouble(double: Double) {
  * @param float the floating point number to be written.
  *
  * @throws IllegalStateException when the sink is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeFloatLe
  */
@@ -330,6 +345,7 @@ public fun Sink.writeFloatLe(float: Float) {
  * @param double the floating point number to be written.
  *
  * @throws IllegalStateException when the sink is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeDoubleLe
  */
@@ -349,6 +365,7 @@ public fun Sink.writeDoubleLe(double: Double) {
  * @param lambda the callback accessing internal buffer.
  *
  * @throws IllegalStateException when the sink is closed.
+ * @throws IOException when some I/O error occurs.
  */
 @DelicateIoApi
 @OptIn(InternalIoApi::class)

--- a/core/common/src/Source.kt
+++ b/core/common/src/Source.kt
@@ -77,6 +77,7 @@ public sealed interface Source : RawSource {
    * The call of this method will block until there are bytes to read or the source is definitely exhausted.
    *
    * @throws IllegalStateException when the source is closed.
+   * @throws IOException when some I/O error occurs.
    *
    * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.exhausted
    */
@@ -94,6 +95,7 @@ public sealed interface Source : RawSource {
    * @throws EOFException when the source is exhausted before the required bytes count could be read.
    * @throws IllegalStateException when the source is closed.
    * @throws IllegalArgumentException when [byteCount] is negative.
+   * @throws IOException when some I/O error occurs.
    *
    * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.require
    */
@@ -110,6 +112,7 @@ public sealed interface Source : RawSource {
    *
    * @throws IllegalArgumentException when [byteCount] is negative.
    * @throws IllegalStateException when the source is closed.
+   * @throws IOException when some I/O error occurs.
    *
    * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.request
    */
@@ -120,6 +123,7 @@ public sealed interface Source : RawSource {
    *
    * @throws EOFException when there are no more bytes to read.
    * @throws IllegalStateException when the source is closed.
+   * @throws IOException when some I/O error occurs.
    *
    * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readByte
    */
@@ -130,6 +134,7 @@ public sealed interface Source : RawSource {
    *
    * @throws EOFException when there are not enough data to read a short value.
    * @throws IllegalStateException when the source is closed.
+   * @throws IOException when some I/O error occurs.
    *
    * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readShort
    */
@@ -140,6 +145,7 @@ public sealed interface Source : RawSource {
    *
    * @throws EOFException when there are not enough data to read an int value.
    * @throws IllegalStateException when the source is closed.
+   * @throws IOException when some I/O error occurs.
    *
    * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readInt
    */
@@ -150,6 +156,7 @@ public sealed interface Source : RawSource {
    *
    * @throws EOFException when there are not enough data to read a long value.
    * @throws IllegalStateException when the source is closed.
+   * @throws IOException when some I/O error occurs.
    *
    * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readLong
    */
@@ -163,6 +170,7 @@ public sealed interface Source : RawSource {
    * @throws EOFException when the source is exhausted before the requested number of bytes can be skipped.
    * @throws IllegalArgumentException when [byteCount] is negative.
    * @throws IllegalStateException when the source is closed.
+   * @throws IOException when some I/O error occurs.
    *
    * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.skip
    */
@@ -179,6 +187,7 @@ public sealed interface Source : RawSource {
    * @throws IndexOutOfBoundsException when [startIndex] or [endIndex] is out of range of [sink] array indices.
    * @throws IllegalArgumentException when `startIndex > endIndex`.
    * @throws IllegalStateException when the source is closed.
+   * @throws IOException when some I/O error occurs.
    *
    * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readAtMostToByteArray
    */
@@ -193,6 +202,7 @@ public sealed interface Source : RawSource {
    * @throws IllegalArgumentException when [byteCount] is negative.
    * @throws EOFException when the requested number of bytes cannot be read.
    * @throws IllegalStateException when the source or [sink] is closed.
+   * @throws IOException when some I/O error occurs.
    *
    * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readSourceToSink
    */
@@ -207,6 +217,7 @@ public sealed interface Source : RawSource {
    * @param sink the sink to which data will be written from this source.
    *
    * @throws IllegalStateException when the source or [sink] is closed.
+   * @throws IOException when some I/O error occurs.
    *
    * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.transferTo
    */

--- a/core/common/src/Sources.kt
+++ b/core/common/src/Sources.kt
@@ -10,6 +10,7 @@ package kotlinx.io
  *
  * @throws EOFException when there are not enough data to read a short value.
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readShortLe
  */
@@ -22,6 +23,7 @@ public fun Source.readShortLe(): Short {
  *
  * @throws EOFException when there are not enough data to read an int value.
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readIntLe
  */
@@ -34,6 +36,7 @@ public fun Source.readIntLe(): Int {
  *
  * @throws EOFException when there are not enough data to read a long value.
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readLongLe
  */
@@ -55,6 +58,7 @@ internal const val OVERFLOW_DIGIT_START = Long.MIN_VALUE % 10L + 1
  * number was not present.
  * @throws EOFException if the source is exhausted before a call of this method.
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readDecimalLong
  */
@@ -126,6 +130,7 @@ public fun Source.readDecimalLong(): Long {
  * hexadecimal was not found.
  * @throws EOFException if the source is exhausted before a call of this method.
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readHexLong
  */
@@ -178,6 +183,7 @@ public fun Source.readHexadecimalUnsignedLong(): Long {
  *
  * @throws IllegalStateException when the source is closed.
  * @throws IllegalArgumentException when `startIndex > endIndex` or either of indices is negative.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.indexOfByteSample
  */
@@ -207,6 +213,7 @@ public fun Source.indexOf(byte: Byte, startIndex: Long = 0L, endIndex: Long = Lo
  * Removes all bytes from this source and returns them as a byte array.
  *
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readToArraySample
  */
@@ -222,6 +229,7 @@ public fun Source.readByteArray(): ByteArray {
  * @throws IllegalArgumentException when [byteCount] is negative.
  * @throws EOFException when the underlying source is exhausted before [byteCount] bytes of data could be read.
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readToArraySample
  */
@@ -261,6 +269,7 @@ private fun Source.readByteArrayImpl(size: Int): ByteArray {
  * @throws IllegalStateException when the source is closed.
  * @throws IndexOutOfBoundsException when [startIndex] or [endIndex] is out of range of [sink] array indices.
  * @throws IllegalArgumentException when `startIndex > endIndex`.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readToArraySample
  */
@@ -284,6 +293,7 @@ public fun Source.readTo(sink: ByteArray, startIndex: Int = 0, endIndex: Int = s
  *
  * @throws EOFException when there are no more bytes to read.
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readUByte
  */
@@ -295,6 +305,7 @@ public fun Source.readUByte(): UByte = readByte().toUByte()
  *
  * @throws EOFException when there are not enough data to read an unsigned short value.
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readUShort
  */
@@ -306,6 +317,7 @@ public fun Source.readUShort(): UShort = readShort().toUShort()
  *
  * @throws EOFException when there are not enough data to read an unsigned int value.
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readUInt
  */
@@ -317,6 +329,7 @@ public fun Source.readUInt(): UInt = readInt().toUInt()
  *
  * @throws EOFException when there are not enough data to read an unsigned long value.
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readULong
  */
@@ -328,6 +341,7 @@ public fun Source.readULong(): ULong = readLong().toULong()
  *
  * @throws EOFException when there are not enough data to read an unsigned short value.
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readUShortLe
  */
@@ -339,6 +353,7 @@ public fun Source.readUShortLe(): UShort = readShortLe().toUShort()
  *
  * @throws EOFException when there are not enough data to read an unsigned int value.
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readUIntLe
  */
@@ -350,6 +365,7 @@ public fun Source.readUIntLe(): UInt = readIntLe().toUInt()
  *
  * @throws EOFException when there are not enough data to read an unsigned long value.
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readULongLe
  */
@@ -367,6 +383,7 @@ public fun Source.readULongLe(): ULong = readLongLe().toULong()
  *
  * @throws EOFException when there are not enough data to read an unsigned int value.
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readFloat
  */
@@ -380,6 +397,7 @@ public fun Source.readFloat(): Float = Float.fromBits(readInt())
  *
  * @throws EOFException when there are not enough data to read an unsigned int value.
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readDouble
  */
@@ -397,6 +415,7 @@ public fun Source.readDouble(): Double = Double.fromBits(readLong())
  *
  * @throws EOFException when there are not enough data to read an unsigned int value.
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readFloatLe
  */
@@ -410,6 +429,7 @@ public fun Source.readFloatLe(): Float = Float.fromBits(readIntLe())
  *
  * @throws EOFException when there are not enough data to read an unsigned int value.
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readDoubleLe
  */
@@ -422,6 +442,7 @@ public fun Source.readDoubleLe(): Double = Double.fromBits(readLongLe())
  * If there is no buffered data, this call will result in a fetch from the underlying source.
  *
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.startsWithSample
  */

--- a/core/common/src/Utf8.kt
+++ b/core/common/src/Utf8.kt
@@ -140,6 +140,7 @@ internal fun String.utf8Size(startIndex: Int = 0, endIndex: Int = length): Long 
  *
  * @throws IllegalStateException when the sink is closed.
  * @throws IllegalArgumentException when [codePoint] value is negative, or greater than `U+10ffff`.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeUtf8CodePointSample
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeSurrogatePair
@@ -158,6 +159,7 @@ public fun Sink.writeCodePointValue(codePoint: Int): Unit =
  * @throws IndexOutOfBoundsException when [startIndex] or [endIndex] is out of range of [string] indices.
  * @throws IllegalArgumentException when `startIndex > endIndex`.
  * @throws IllegalStateException when the sink is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeUtf8Sample
  */
@@ -178,6 +180,7 @@ public fun Sink.writeString(string: String, startIndex: Int = 0, endIndex: Int =
  * @throws IndexOutOfBoundsException when [startIndex] or [endIndex] is out of range of [chars] indices.
  * @throws IllegalArgumentException when `startIndex > endIndex`.
  * @throws IllegalStateException when the sink is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.writeUtf8SeqSample
  */
@@ -194,6 +197,7 @@ public fun Sink.writeString(chars: CharSequence, startIndex: Int = 0, endIndex: 
  * Returns the empty string if this source is empty.
  *
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readUtf8
  */
@@ -225,6 +229,7 @@ public fun Buffer.readString(): String {
  * @throws IllegalArgumentException when [byteCount] is negative.
  * @throws EOFException when the source is exhausted before reading [byteCount] bytes from it.
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readUtf8
  */
@@ -254,6 +259,7 @@ public fun Source.readString(byteCount: Long): String {
  *
  * @throws EOFException when the source is exhausted before a complete code point can be read.
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readUtf8CodePointSample
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.surrogatePairs
@@ -283,6 +289,7 @@ public fun Source.readCodePointValue(): Int {
  * an implicit line break is assumed. Null is returned once the source is exhausted.
  *
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readLinesSample
  */
@@ -328,6 +335,7 @@ public fun Source.readLine(): String? {
  * line break characters.
  * @throws IllegalStateException when the source is closed.
  * @throws IllegalArgumentException when [limit] is negative.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoCoreCommonSamples.readLinesSample
  */

--- a/core/jvm/src/SinksJvm.kt
+++ b/core/jvm/src/SinksJvm.kt
@@ -38,6 +38,7 @@ import java.nio.charset.Charset
  * @throws IndexOutOfBoundsException when [startIndex] or [endIndex] is out of range of [string] indices.
  * @throws IllegalArgumentException when `startIndex > endIndex`.
  * @throws IllegalStateException when the sink is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoSamplesJvm.readWriteStrings
  */
@@ -92,6 +93,7 @@ public fun Sink.asOutputStream(): OutputStream {
  * @param source the source to read from.
  *
  * @throws IllegalStateException when the sink is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoSamplesJvm.readWriteByteBuffer
  */

--- a/core/jvm/src/SourcesJvm.kt
+++ b/core/jvm/src/SourcesJvm.kt
@@ -58,6 +58,7 @@ private fun Buffer.readStringImpl(byteCount: Long, charset: Charset): String {
  * @param charset the [Charset] to use for string decoding.
  *
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoSamplesJvm.readWriteStrings
  */
@@ -79,6 +80,7 @@ public fun Source.readString(charset: Charset): String {
  * @throws EOFException when the source exhausted before [byteCount] bytes could be read from it.
  * @throws IllegalStateException when the source is closed.
  * @throws IllegalArgumentException if [byteCount] is negative or its value is greater than [Int.MAX_VALUE].
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoSamplesJvm.readStringBounded
  */
@@ -135,6 +137,7 @@ public fun Source.asInputStream(): InputStream {
  * @param sink the sink to write the data to.
  *
  * @throws IllegalStateException when the source is closed.
+ * @throws IOException when some I/O error occurs.
  *
  * @sample kotlinx.io.samples.KotlinxIoSamplesJvm.readWriteByteBuffer
  */


### PR DESCRIPTION
Previously, it was unclear how `RawSink`/`RawSource` implementations should behave when I/O errors occur.
This PR adds explicit `IOException` mentions to `@throws` lists of these interfaces and also propagates it to all functions that are transitively affected.

Closes #302 