### PR TITLE
Minor cleanup and simplification of readString

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -9,3 +9,12 @@ Currently, the suite includes benchmarks on:
 
 The suite doesn't include benchmarks for more complex APIs inherited from Okio as these APIs are subject to change.
 Such benchmarks will be added later along with corresponding changes in the library.
+
+### Quickstart
+
+For JVM:
+```
+./gradlew :kotlinx-io-benchmarks:jvmJar
+
+java -jar benchmarks/build/benchmarks/jvm/jars/kotlinx-io-benchmarks-jvm-jmh-0.6.0-SNAPSHOT-JMH.jar  ReadStringBenchmark -f 1 -wi 5 -i 5 -tu us -w 1 -r 1
+```

--- a/benchmarks/src/commonMain/kotlin/ReadStringBenchmark.kt
+++ b/benchmarks/src/commonMain/kotlin/ReadStringBenchmark.kt
@@ -17,7 +17,7 @@ import kotlin.random.Random
 @State(Scope.Benchmark)
 open class ReadStringBenchmark() {
 
-    @Param("16", "64", "512")
+    @Param("16", "64", "512") // Fits into a single segment, so the benchmark does not measure segment boundaries crossing
     var size: Int = 0
 
     val buffer: Buffer = Buffer()

--- a/benchmarks/src/commonMain/kotlin/ReadStringBenchmark.kt
+++ b/benchmarks/src/commonMain/kotlin/ReadStringBenchmark.kt
@@ -1,0 +1,42 @@
+package kotlinx.io.benchmarks
+
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.Param
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.io.Buffer
+import kotlinx.io.Source
+import kotlinx.io.readCodePointValue
+import kotlinx.io.readString
+import kotlinx.io.writeCodePointValue
+import kotlinx.io.writeString
+import kotlin.random.Random
+
+
+@State(Scope.Benchmark)
+open class ReadStringBenchmark() {
+
+    @Param("16", "64", "512")
+    var size: Int = 0
+
+    val buffer: Buffer = Buffer()
+
+    @Setup
+    fun setup() {
+        val string = buildString { repeat(size) { append(('a'..'z').random()) } }
+        buffer.writeString(string)
+    }
+
+
+    @Benchmark
+    fun bufferReadString(): String {
+        return buffer.copy().readString()
+    }
+
+    @Benchmark
+    fun sourceReadString(): String {
+        val source: Source = buffer.copy()
+        return source.readString()
+    }
+}


### PR DESCRIPTION
* Request Long.MAX_VALUE from the source at once (note: no need for a loop as we are unable to build the string of such size anyway)
* Get rid of redundant checks in commonReadUtf8

Ticks one of the boxes in #342