### PR TITLE
Update samples that do not work in Playground

### DIFF
--- a/core/common/test/samples/byteStringSample.kt
+++ b/core/common/test/samples/byteStringSample.kt
@@ -8,9 +8,7 @@ package kotlinx.io.samples
 import kotlinx.io.*
 import kotlinx.io.bytestring.ByteString
 import kotlinx.io.bytestring.encodeToByteString
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 class ByteStringSamples {
     @Test

--- a/core/common/test/samples/moduleDescriptionSample.kt
+++ b/core/common/test/samples/moduleDescriptionSample.kt
@@ -6,8 +6,7 @@
 package kotlinx.io.samples
 
 import kotlinx.io.*
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import kotlin.test.*
 
 data class Message(val timestamp: Long, val text: String) {
     companion object

--- a/core/common/test/samples/rawSinkSample.kt
+++ b/core/common/test/samples/rawSinkSample.kt
@@ -6,8 +6,7 @@
 package kotlinx.io.samples
 
 import kotlinx.io.*
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import kotlin.test.*
 
 class Crc32Sample {
     @OptIn(ExperimentalUnsignedTypes::class)
@@ -25,7 +24,7 @@ class Crc32Sample {
             private var crc32: UInt = 0xffffffffU
 
             private fun update(value: Byte) {
-                val index = value.xor(crc32.toByte()).toUByte()
+                val index = value.toUInt().xor(crc32).toUByte()
                 crc32 = crc32Table[index.toInt()].xor(crc32.shr(8))
             }
 

--- a/core/common/test/samples/rawSourceSample.kt
+++ b/core/common/test/samples/rawSourceSample.kt
@@ -6,8 +6,7 @@
 package kotlinx.io.samples
 
 import kotlinx.io.*
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import kotlin.test.*
 
 class RC4SourceSample {
     @Test

--- a/core/common/test/samples/unsafe/unsafeSamples.kt
+++ b/core/common/test/samples/unsafe/unsafeSamples.kt
@@ -13,9 +13,7 @@ import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.math.min
 import kotlin.random.Random
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 class UnsafeBufferOperationsSamples {
     @OptIn(UnsafeIoApi::class)

--- a/core/jvm/test/samples/samplesJvm.kt
+++ b/core/jvm/test/samples/samplesJvm.kt
@@ -11,10 +11,7 @@ import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
-import kotlin.test.Test
-import kotlin.test.assertContentEquals
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import kotlin.test.*
 
 class KotlinxIoSamplesJvm {
     @Test

--- a/core/jvm/test/samples/unsafeAccessSamplesJvm.kt
+++ b/core/jvm/test/samples/unsafeAccessSamplesJvm.kt
@@ -20,8 +20,7 @@ import java.nio.file.Files
 import java.nio.file.StandardOpenOption
 import java.security.MessageDigest
 import kotlin.random.Random
-import kotlin.test.Test
-import kotlin.test.assertEquals
+import kotlin.test.*
 
 @OptIn(UnsafeIoApi::class)
 class UnsafeReadWriteSamplesJvm {


### PR DESCRIPTION
- fixed imports to avoid explicit kotlin.test.Test import
- removed all internal function uses from samples