### PR TITLE
Update error message in `writableSegment`

### DIFF
--- a/core/common/src/Buffer.kt
+++ b/core/common/src/Buffer.kt
@@ -352,7 +352,9 @@ public class Buffer : Source, Sink {
     @PublishedApi
     @JvmSynthetic
     internal fun writableSegment(minimumCapacity: Int): Segment {
-        require(minimumCapacity >= 1 && minimumCapacity <= Segment.SIZE) { "unexpected capacity" }
+        require(minimumCapacity >= 1 && minimumCapacity <= Segment.SIZE) {
+            "unexpected capacity ($minimumCapacity), should be in range [1, ${Segment.SIZE}]"
+        }
 
         if (tail == null) {
             val result = SegmentPool.take() // Acquire a first segment.


### PR DESCRIPTION
During implementation for support of `kotlinx-io` in `cryptography-kotlin` at one point I've started to receive the error about `unexpected capacity`, but it was not really informative. The reason for this was, that I haven't handled the case with output of zero size [here](https://github.com/whyoleg/cryptography-kotlin/blob/639b142aa447d882f9c0361b6d7368423c21c47c/cryptography-providers/base/src/commonMain/kotlin/operations/BaseCipherFunction.kt#L128-L141).
It would be nice to have the error message more clear on what's wrong, when using `UnsafeBufferOperations.writeToTail`