### PR TITLE
Delegate Int|Short|Long.reverseBytes to Java Stdlib

### DIFF
--- a/core/common/src/-Util.kt
+++ b/core/common/src/-Util.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 JetBrains s.r.o. and respective authors and developers.
+ * Copyright 2017-2024 JetBrains s.r.o. and respective authors and developers.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENCE file.
  */
 
@@ -52,21 +52,27 @@ internal inline fun checkByteCount(byteCount: Long) {
     require(byteCount >= 0) { "byteCount ($byteCount) < 0" }
 }
 
-internal fun Short.reverseBytes(): Short {
+internal expect fun Short.reverseBytes(): Short
+
+internal inline fun Short.reverseBytesCommon(): Short {
     val i = toInt() and 0xffff
     val reversed = (i and 0xff00 ushr 8) or
             (i and 0x00ff shl 8)
     return reversed.toShort()
 }
 
-internal fun Int.reverseBytes(): Int {
+internal expect fun Int.reverseBytes(): Int
+
+internal inline fun Int.reverseBytesCommon(): Int {
     return (this and -0x1000000 ushr 24) or
             (this and 0x00ff0000 ushr 8) or
             (this and 0x0000ff00 shl 8) or
             (this and 0x000000ff shl 24)
 }
 
-internal fun Long.reverseBytes(): Long {
+internal expect fun Long.reverseBytes(): Long
+
+internal inline fun Long.reverseBytesCommon(): Long {
     return (this and -0x100000000000000L ushr 56) or
             (this and 0x00ff000000000000L ushr 40) or
             (this and 0x0000ff0000000000L ushr 24) or
@@ -78,14 +84,6 @@ internal fun Long.reverseBytes(): Long {
 }
 
 /* ktlint-enable no-multi-spaces indent */
-
-internal inline infix fun Int.leftRotate(bitCount: Int): Int {
-    return (this shl bitCount) or (this ushr (32 - bitCount))
-}
-
-internal inline infix fun Long.rightRotate(bitCount: Int): Long {
-    return (this ushr bitCount) or (this shl (64 - bitCount))
-}
 
 // Syntactic sugar.
 internal inline infix fun Byte.shr(other: Int): Int = toInt() shr other

--- a/core/js/src/UtilsJs.kt
+++ b/core/js/src/UtilsJs.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2010-2024 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENCE file.
+ */
+
+package kotlinx.io
+
+internal actual fun Short.reverseBytes(): Short = reverseBytesCommon()
+internal actual fun Int.reverseBytes(): Int = reverseBytesCommon()
+internal actual fun Long.reverseBytes(): Long = reverseBytesCommon()

--- a/core/jvm/src/-UtilsJvm.kt
+++ b/core/jvm/src/-UtilsJvm.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2010-2024 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENCE file.
+ */
+
+package kotlinx.io
+
+internal actual fun Short.reverseBytes(): Short = java.lang.Short.reverseBytes(this)
+internal actual fun Int.reverseBytes(): Int = java.lang.Integer.reverseBytes(this)
+internal actual fun Long.reverseBytes(): Long = java.lang.Long.reverseBytes(this)

--- a/core/native/src/UtilsNative.kt
+++ b/core/native/src/UtilsNative.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2010-2024 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENCE file.
+ */
+
+package kotlinx.io
+
+internal actual fun Short.reverseBytes(): Short = reverseBytesCommon()
+internal actual fun Int.reverseBytes(): Int = reverseBytesCommon()
+internal actual fun Long.reverseBytes(): Long = reverseBytesCommon()

--- a/core/wasm/src/UtilsWasm.kt
+++ b/core/wasm/src/UtilsWasm.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2010-2024 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENCE file.
+ */
+
+package kotlinx.io
+
+internal actual fun Short.reverseBytes(): Short = reverseBytesCommon()
+internal actual fun Int.reverseBytes(): Int = reverseBytesCommon()
+internal actual fun Long.reverseBytes(): Long = reverseBytesCommon()


### PR DESCRIPTION
Seems like JVM's JIT compiler can't pattern match bytes reversal, so it's worth explicitly delegating to Java Stdlib functions, that are intrinsics candidates.

For long values, the new implementation shows 20% perf improvement for reversal itself.

Functions depending on it, like readXXXLe or writeXXXLe also show some moderate performance improvement from the change:
- baseline (develop):
```
Benchmark                   (minGap)   Mode  Cnt          Score          Error  Units
IntLeBenchmark.benchmark         128  thrpt   15  387643797.206 ± 13843848.182  ops/s
LongLeBenchmark.benchmark        128  thrpt   15  314485977.158 ±  2249441.675  ops/s
ShortLeBenchmark.benchmark       128  thrpt   15  433907914.224 ±  6445437.883  ops/s
```

- optimized (this PR):
```
Benchmark                   (minGap)   Mode  Cnt          Score          Error  Units
IntLeBenchmark.benchmark         128  thrpt   15  432487978.191 ± 29393229.522  ops/s
LongLeBenchmark.benchmark        128  thrpt   15  336771673.575 ±  6093734.967  ops/s
ShortLeBenchmark.benchmark       128  thrpt   15  440459420.611 ± 11852873.667  ops/s
```