### PR TITLE
Fix JVM toolchain version for smoke tests

### DIFF
--- a/smoke-tests/src/test/resources/templates/jvm.build.gradle.kts
+++ b/smoke-tests/src/test/resources/templates/jvm.build.gradle.kts
@@ -24,3 +24,7 @@ dependencies {
     implementation("%DEPENDENCY%")
     testImplementation(kotlin("test"))
 }
+
+kotlin {
+    jvmToolchain(8)
+}

--- a/smoke-tests/src/test/resources/templates/kmp.build.gradle.kts
+++ b/smoke-tests/src/test/resources/templates/kmp.build.gradle.kts
@@ -25,6 +25,8 @@ repositories {
 
 @OptIn(ExperimentalWasmDsl::class)
 kotlin {
+    jvmToolchain(8)
+
     jvm()
     js(IR) {
         browser {

--- a/smoke-tests/src/test/resources/templates/settings.gradle.kts
+++ b/smoke-tests/src/test/resources/templates/settings.gradle.kts
@@ -10,3 +10,7 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version ("0.8.0")
+}


### PR DESCRIPTION
By using lowest supported JVM toolchain (8), we should be able to catch an unintentional class file version change.