### PR TITLE
Introduce ByteString based on an existing ByteArray

### DIFF
--- a/bytestring/common/src/ByteStringBuilder.kt
+++ b/bytestring/common/src/ByteStringBuilder.kt
@@ -79,8 +79,11 @@ public class ByteStringBuilder private constructor(
      * @param byte the byte to append.
      */
     public fun append(byte: Byte) {
-        ensureCapacity(size + 1)
-        buffer[offset++] = byte
+		val newOffset = offset + 1
+        ensureCapacity(newOffset)
+
+        buffer[offset] = byte
+	    offset = newOffset
     }
 
     /**

--- a/bytestring/common/test/ByteStringBuilderTest.kt
+++ b/bytestring/common/test/ByteStringBuilderTest.kt
@@ -15,6 +15,41 @@ class ByteStringBuilderTest {
     fun emptyString() {
         assertTrue(ByteStringBuilder().toByteString().isEmpty())
         assertTrue(ByteStringBuilder(1024).toByteString().isEmpty())
+        assertTrue(ByteStringBuilder(byteArrayOf()).toByteString().isEmpty())
+    }
+
+    @Test
+    fun customBuffer() {
+        val byteArray = byteArrayOf(125, 126, 127)
+
+        assertEquals(ByteStringBuilder(byteArray).toByteString(), ByteString(byteArray))
+    }
+
+    @Test
+    fun appendByteToCustomBuffer() {
+        ByteStringBuilder(byteArrayOf(125, 126, 127)).apply {
+            append(1)
+            append(2)
+            append(3)
+            assertEquals(toByteString(), ByteString(1, 2, 3))
+
+            assertFailsWith<IndexOutOfBoundsException> {
+                append(4)
+            }
+        }
+    }
+
+    @Test
+    fun appendByteToCustomBufferWithCustomOffset() {
+        ByteStringBuilder(byteArrayOf(125, 126, 127), initialOffset = 1).apply {
+            append(2)
+            append(3)
+            assertEquals(toByteString(), ByteString(125, 2, 3))
+
+            assertFailsWith<IndexOutOfBoundsException> {
+                append(4)
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
I implemented this using an existing class and an `extendable` boolean as I didn't want to break binary compatibility with existing usage of the `ByteStringBuilder` constructor, but it is possible to rewrite using an abstract class (should be ever-so-slightly-faster).

My use case: I have a game engine, and I'd like to avoid copying data around more than necessary. Usually, this would be a micro-optimization; But re-meshing everything every frame adds up quickly. This way, I can pass my existing vertex buffer, and an offset (that I can record using the buffer's own `size`), and simply override the changed vertex's data.

I did not add a `buildByteString` function as this is a lower-level use-case and should be treated as such; I expect most to not need the resulting `ByteString` at all, and simply use `apply` instead.

I would add a `DelicateIoApi` annotation, but I didn't seem to find one.