### PR TITLE
Use SPDX identifier in POMs

### DIFF
--- a/build-logic/src/main/kotlin/kotlinx/io/conventions/kotlinx-io-publish.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlinx/io/conventions/kotlinx-io-publish.gradle.kts
@@ -35,7 +35,7 @@ fun MavenPom.configureMavenCentralMetadata(project: Project) {
 
     licenses {
         license {
-            name = "The Apache Software License, Version 2.0"
+            name = "Apache-2.0"
             url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
             distribution = "repo"
         }


### PR DESCRIPTION
This replaces the custom name with an SPDX identifier to enable tooling to automatically detect the correct license. Using an SPDX identifier is recommended [by the official Maven documentation](https://maven.apache.org/pom.html#Licenses).

See https://spdx.org/licenses/Apache-2.0.html