### PR TITLE
Fix ArrayIndexOutOfBoundsException in okio.Sink.asKotlinxIoRawSink

### DIFF
--- a/integration/kotlinx-io-okio/common/src/OkioAdapters.kt
+++ b/integration/kotlinx-io-okio/common/src/OkioAdapters.kt
@@ -109,8 +109,8 @@ public fun okio.Sink.asKotlinxIoRawSink(): RawSink = object : RawSink {
                 buffer.write(data, from, toRead)
                 toRead
             }
-            this@asKotlinxIoRawSink.write(buffer, byteCount)
         }
+        this@asKotlinxIoRawSink.write(buffer, byteCount)
     }
 
     override fun flush() = withOkio2KxIOExceptionMapping {

--- a/integration/kotlinx-io-okio/common/test/OkioAdaptersTest.kt
+++ b/integration/kotlinx-io-okio/common/test/OkioAdaptersTest.kt
@@ -53,6 +53,19 @@ class OkioAdaptersTest {
     }
 
     @Test
+    fun okioSinkLargeWrite() {
+        val arrayLength = 8193
+        val data = ByteArray(arrayLength) { it.toByte() }
+        val kxBuffer = kotlinx.io.Buffer().also { it.write(data) }
+        val okioBuffer = okio.Buffer()
+        val okioSink = okioBuffer as okio.Sink
+        val wrapper = okioSink.asKotlinxIoRawSink()
+        wrapper.write(kxBuffer, arrayLength.toLong())
+        assertContentEquals(data, okioBuffer.readByteArray())
+        assertTrue(kxBuffer.exhausted())
+    }
+
+    @Test
     fun okioSinkViewDelegation() {
         var closed = false
         var flushed = false


### PR DESCRIPTION
When byteCount > okio segment size