### PR TITLE
Increase deprecation level for Path.source/sink

### DIFF
--- a/core/common/src/files/Paths.kt
+++ b/core/common/src/files/Paths.kt
@@ -100,7 +100,8 @@ public fun Path(base: Path, vararg parts: String): Path {
 /**
  * Returns [RawSource] for the given file or throws if path is not a file or does not exist
  *
- * Use of this method is deprecated with warning since kotlinx-io 0.3.0. The method will be removed in 0.7.0.
+ * Use of this method is deprecated with warning since kotlinx-io 0.3.0, with error since 0.8.0,
+ * and it will be removed in the future.
  */
 @Deprecated(
     message = "Use FileSystem.source instead",
@@ -108,7 +109,7 @@ public fun Path(base: Path, vararg parts: String): Path {
         expression = "SystemFileSystem.source(this).buffered()",
         imports = arrayOf("kotlinx.io.files.FileSystem")
     ),
-    level = DeprecationLevel.WARNING
+    level = DeprecationLevel.ERROR
 )
 @JvmName("sourceDeprecated")
 public fun Path.source(): Source = SystemFileSystem.source(this).buffered()
@@ -117,7 +118,8 @@ public fun Path.source(): Source = SystemFileSystem.source(this).buffered()
  * Returns [RawSink] for the given path, creates file if it doesn't exist, throws if it's a directory,
  * overwrites contents.
  *
- * Use of this method is deprecated with warning since kotlinx-io 0.3.0. The method will be removed in 0.7.0.
+ * Use of this method is deprecated with warning since kotlinx-io 0.3.0, with error since 0.8.0,
+ * and it will be removed in the future.
  */
 @Deprecated(
     message = "Use FileSystem.sink instead",
@@ -125,7 +127,7 @@ public fun Path.source(): Source = SystemFileSystem.source(this).buffered()
         expression = "SystemFileSystem.sink(this).buffered()",
         imports = arrayOf("kotlinx.io.files.FileSystem")
     ),
-    level = DeprecationLevel.WARNING
+    level = DeprecationLevel.ERROR
 )
 @JvmName("sinkDeprecated")
 public fun Path.sink(): Sink = SystemFileSystem.sink(this).buffered()


### PR DESCRIPTION
These functions were deprecated with warning for a while. Their removal was postponed from release to
release, and it's time to at least increase the deprecation level to error.