### PR TITLE
Making FileNotFoundException to allow subclassing it

### DIFF
--- a/core/common/src/files/FileSystem.kt
+++ b/core/common/src/files/FileSystem.kt
@@ -210,7 +210,7 @@ public class FileMetadata(
 /**
  * Signals an I/O operation's failure due to a missing file or directory.
  */
-public expect class FileNotFoundException(message: String?) : IOException
+public expect open class FileNotFoundException(message: String?) : IOException
 
 internal const val WindowsPathSeparator: Char = '\\'
 internal const val UnixPathSeparator: Char = '/'


### PR DESCRIPTION
In some cases, we would like to subclass FileNotFoundException (the same way it subclasses IOException for example). But it was currently not possible since it was not open.

Example from [kdriver](https://github.com/guimauvedigital/kdriver):
```kotlin
class BrowserExecutableNotFoundException : FileNotFoundException(
    """
    Could not determine browser executable.
    Make sure your browser is installed in the default location (path).
    Or specify browserExecutablePath parameter.
    """.trimIndent()
)
```

This is okay on JVM, but does not work on other platforms yet (until this PR gets merged and released 😎)