### PR TITLE
FileMetadata with last modification information #463

### DIFF
--- a/core/apple/src/files/FileSystemApple.kt
+++ b/core/apple/src/files/FileSystemApple.kt
@@ -74,14 +74,14 @@ internal actual fun metadataOrNullImpl(path: Path): FileMetadata? {
         isDirectory = isDir,
         size = if (isFile) attributes[NSFileSize] as Long else -1,
         createdAt = createdAt,
-        updatedAt = updatedAt,
+        lastModificationTime = updatedAt,
     )
 }
 
 private fun NSDate.toInstant(): Instant {
     val nanosInSecond = 1_000_000_000L
     val epochSeconds = this.timeIntervalSince1970
-    val epochSecondsTruncated = epoch.toLong()
+    val epochSecondsTruncated = epochSeconds.toLong()
     val nanos = (epochSeconds - epochSecondsTruncated).times(nanosInSecond).toLong()
     return Instant.fromEpochSeconds(epochSecondsTruncated, nanos)
 }

--- a/core/apple/src/files/FileSystemApple.kt
+++ b/core/apple/src/files/FileSystemApple.kt
@@ -79,8 +79,9 @@ internal actual fun metadataOrNullImpl(path: Path): FileMetadata? {
 }
 
 private fun NSDate.toInstant(): Instant {
-    val epoch = this.timeIntervalSince1970
-    val seconds = epoch.toLong()
-    val nanos = (epoch - seconds).times(1e9).toLong()
-    return Instant.fromEpochSeconds(seconds, nanos)
+    val nanosInSecond = 1_000_000_000L
+    val epochSeconds = this.timeIntervalSince1970
+    val epochSecondsTruncated = epoch.toLong()
+    val nanos = (epochSeconds - epochSecondsTruncated).times(nanosInSecond).toLong()
+    return Instant.fromEpochSeconds(epochSecondsTruncated, nanos)
 }

--- a/core/apple/src/files/FileSystemApple.kt
+++ b/core/apple/src/files/FileSystemApple.kt
@@ -10,7 +10,6 @@ import kotlinx.cinterop.*
 import kotlinx.io.IOException
 import platform.Foundation.*
 import platform.posix.*
-import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
 
@@ -55,7 +54,6 @@ internal actual fun realpathImpl(path: String): String {
     }
 }
 
-@OptIn(ExperimentalTime::class)
 internal actual fun metadataOrNullImpl(path: Path): FileMetadata? {
     val attributes = NSFileManager.defaultManager().fileAttributesAtPath(path.path, traverseLink = true) ?: return null
     val fileType = attributes[NSFileType] as String
@@ -80,7 +78,6 @@ internal actual fun metadataOrNullImpl(path: Path): FileMetadata? {
     )
 }
 
-@OptIn(ExperimentalTime::class)
 private fun NSDate.toInstant(): Instant {
     val epoch = this.timeIntervalSince1970
     val seconds = epoch.toLong()

--- a/core/apple/src/files/FileSystemApple.kt
+++ b/core/apple/src/files/FileSystemApple.kt
@@ -74,7 +74,7 @@ internal actual fun metadataOrNullImpl(path: Path): FileMetadata? {
         isDirectory = isDir,
         size = if (isFile) attributes[NSFileSize] as Long else -1,
         createdAt = createdAt,
-        lastModificationTime = updatedAt,
+        lastModifiedAt = updatedAt,
     )
 }
 

--- a/core/common/src/files/FileSystem.kt
+++ b/core/common/src/files/FileSystem.kt
@@ -8,6 +8,8 @@ package kotlinx.io.files
 import kotlinx.io.IOException
 import kotlinx.io.RawSink
 import kotlinx.io.RawSource
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 /**
  * An interface providing basic operations on a filesystem, such as reading and writing files,
@@ -192,6 +194,7 @@ public expect val SystemTemporaryDirectory: Path
  * Represents information about a file or directory obtainable from a filesystem like
  * a type of filesystem node (is it a directory or a file?), its size, and so on.
  */
+@OptIn(ExperimentalTime::class)
 public class FileMetadata(
     /**
      * Flag indicating that the metadata was retrieved for a regular file.
@@ -204,7 +207,15 @@ public class FileMetadata(
     /**
      * File size. Defined only for regular files, for other filesystem entities it will be `-1`.
      */
-    public val size: Long = 0L
+    public val size: Long = 0L,
+    /**
+     * Time when the file was created, or `null` if the filesystem does not support it.
+     */
+    public val createdAt: Instant? = null,
+    /**
+     * Time when the file was last modified, or `null` if the filesystem does not support it.
+     */
+    public val updatedAt: Instant? = null,
 )
 
 /**

--- a/core/common/src/files/FileSystem.kt
+++ b/core/common/src/files/FileSystem.kt
@@ -8,7 +8,6 @@ package kotlinx.io.files
 import kotlinx.io.IOException
 import kotlinx.io.RawSink
 import kotlinx.io.RawSource
-import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
 /**
@@ -194,7 +193,6 @@ public expect val SystemTemporaryDirectory: Path
  * Represents information about a file or directory obtainable from a filesystem like
  * a type of filesystem node (is it a directory or a file?), its size, and so on.
  */
-@OptIn(ExperimentalTime::class)
 public class FileMetadata(
     /**
      * Flag indicating that the metadata was retrieved for a regular file.

--- a/core/common/src/files/FileSystem.kt
+++ b/core/common/src/files/FileSystem.kt
@@ -213,7 +213,7 @@ public class FileMetadata(
     /**
      * Time when the file was last modified, or `null` if the filesystem does not support it.
      */
-    public val updatedAt: Instant? = null,
+    public val lastModificationTime: Instant? = null,
 )
 
 /**

--- a/core/common/src/files/FileSystem.kt
+++ b/core/common/src/files/FileSystem.kt
@@ -213,7 +213,7 @@ public class FileMetadata(
     /**
      * Time when the file was last modified, or `null` if the filesystem does not support it.
      */
-    public val lastModificationTime: Instant? = null,
+    public val lastModifiedAt: Instant? = null,
 )
 
 /**

--- a/core/common/test/files/SmokeFileTest.kt
+++ b/core/common/test/files/SmokeFileTest.kt
@@ -9,10 +9,8 @@ import kotlinx.io.*
 import kotlin.test.*
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
-@OptIn(ExperimentalTime::class)
 class SmokeFileTest {
     private val files: MutableList<Path> = arrayListOf()
 

--- a/core/common/test/files/SmokeFileTest.kt
+++ b/core/common/test/files/SmokeFileTest.kt
@@ -8,8 +8,10 @@ package kotlinx.io.files
 import kotlinx.io.*
 import kotlin.test.*
 import kotlin.time.Clock
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
+import kotlin.time.measureTime
 
 class SmokeFileTest {
     private val files: MutableList<Path> = arrayListOf()
@@ -262,27 +264,37 @@ class SmokeFileTest {
 
     @Test
     fun fileMetadata() {
-        val validateAt: (Instant?) -> Boolean = {
+        val validateAt: (Instant?, Duration) -> Boolean = validateAt@{ at, took ->
+            if (at == null) {
+                return@validateAt true
+            }
             val now = Clock.System.now()
-            val margin = 5.seconds
-            it == null || (now.minus(margin) < it && now.plus(margin) > it)
+            val margin = took + 5.seconds
+            return@validateAt now.minus(margin) < at && now.plus(margin) > at
         }
         val path = createTempPath()
-        val metadata = SystemFileSystem.metadataOrNull(path)
-        assertNull(metadata)
+        assertNull(SystemFileSystem.metadataOrNull(path))
 
-        SystemFileSystem.createDirectories(path)
+        var time = measureTime {
+            SystemFileSystem.createDirectories(path)
+        }
         val dirMetadata = SystemFileSystem.metadataOrNull(path)
         assertNotNull(dirMetadata)
         assertTrue(dirMetadata.isDirectory)
         assertFalse(dirMetadata.isRegularFile)
-        assertTrue(validateAt(dirMetadata.createdAt))
-        assertTrue(validateAt(dirMetadata.updatedAt))
+        assertTrue(validateAt(dirMetadata.createdAt, time))
+        assertTrue(validateAt(dirMetadata.lastModificationTime, time))
 
         val filePath = Path(path, "test.txt")
         assertNull(SystemFileSystem.metadataOrNull(filePath))
-        SystemFileSystem.sink(filePath).buffered().use {
-            it.writeString("blablabla")
+
+        time = measureTime {
+            SystemFileSystem
+                .sink(filePath)
+                .buffered()
+                .use {
+                    it.writeString("blablabla")
+                }
         }
 
         try {
@@ -290,8 +302,8 @@ class SmokeFileTest {
             assertNotNull(fileMetadata)
             assertFalse(fileMetadata.isDirectory)
             assertTrue(fileMetadata.isRegularFile)
-            assertTrue(validateAt(fileMetadata.createdAt))
-            assertTrue(validateAt(fileMetadata.updatedAt))
+            assertTrue(validateAt(fileMetadata.createdAt, time))
+            assertTrue(validateAt(fileMetadata.lastModificationTime, time))
         } finally {
             SystemFileSystem.delete(filePath, false)
         }

--- a/core/common/test/files/SmokeFileTest.kt
+++ b/core/common/test/files/SmokeFileTest.kt
@@ -13,6 +13,8 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 import kotlin.time.measureTime
 
+internal expect val isJVM: Boolean
+
 class SmokeFileTest {
     private val files: MutableList<Path> = arrayListOf()
 
@@ -264,17 +266,17 @@ class SmokeFileTest {
 
     @Test
     fun fileMetadata() {
-        val validateAt: (Instant?, Duration) -> Boolean = validateAt@{ at, took ->
+        val validateAt: (Instant, Instant?, Duration) -> Boolean = validateAt@{ now, at, took ->
             if (at == null) {
                 return@validateAt true
             }
-            val now = Clock.System.now()
             val margin = took + 5.seconds
             return@validateAt now.minus(margin) < at && now.plus(margin) > at
         }
         val path = createTempPath()
         assertNull(SystemFileSystem.metadataOrNull(path))
 
+        var now = Clock.System.now()
         var time = measureTime {
             SystemFileSystem.createDirectories(path)
         }
@@ -282,28 +284,45 @@ class SmokeFileTest {
         assertNotNull(dirMetadata)
         assertTrue(dirMetadata.isDirectory)
         assertFalse(dirMetadata.isRegularFile)
-        assertTrue(validateAt(dirMetadata.createdAt, time))
-        assertTrue(validateAt(dirMetadata.lastModificationTime, time))
+        assertTrue(validateAt(now, dirMetadata.createdAt, time))
+        assertTrue(validateAt(now, dirMetadata.lastModifiedAt, time))
 
         val filePath = Path(path, "test.txt")
         assertNull(SystemFileSystem.metadataOrNull(filePath))
 
-        time = measureTime {
-            SystemFileSystem
-                .sink(filePath)
-                .buffered()
-                .use {
-                    it.writeString("blablabla")
-                }
-        }
-
         try {
-            val fileMetadata = SystemFileSystem.metadataOrNull(filePath)
-            assertNotNull(fileMetadata)
-            assertFalse(fileMetadata.isDirectory)
-            assertTrue(fileMetadata.isRegularFile)
-            assertTrue(validateAt(fileMetadata.createdAt, time))
-            assertTrue(validateAt(fileMetadata.lastModificationTime, time))
+            now = Clock.System.now()
+            time = measureTime {
+                SystemFileSystem
+                    .sink(filePath, append = false)
+                    .buffered()
+                    .use {
+                        it.writeString("blablabla")
+                    }
+            }
+
+            val firstMetadata = SystemFileSystem.metadataOrNull(filePath)
+            assertNotNull(firstMetadata)
+            assertFalse(firstMetadata.isDirectory)
+            assertTrue(firstMetadata.isRegularFile)
+            assertTrue(validateAt(now, firstMetadata.createdAt, time))
+            assertTrue(validateAt(now, firstMetadata.lastModifiedAt, time))
+
+            if (!isJVM) {
+                time = measureTime {
+                    SystemFileSystem
+                        .sink(filePath, append = true)
+                        .buffered()
+                        .use {
+                            it.writeString("again")
+                        }
+                }
+
+                val secondMetadata = SystemFileSystem.metadataOrNull(filePath)
+                assertNotNull(secondMetadata)
+                assertEquals(firstMetadata.createdAt, secondMetadata.createdAt)
+                assertTrue(validateAt(now, secondMetadata.lastModifiedAt, time))
+            }
         } finally {
             SystemFileSystem.delete(filePath, false)
         }

--- a/core/jvm/src/files/FileSystemJvm.kt
+++ b/core/jvm/src/files/FileSystemJvm.kt
@@ -95,7 +95,7 @@ public actual val SystemFileSystem: FileSystem = object : SystemFileSystemImpl()
             isDirectory = path.file.isDirectory,
             size = if (path.file.isFile) path.file.length() else -1L,
             createdAt = attributes.creationTime().toInstant().toKotlinInstant(),
-            updatedAt = path.file.lastModified().let(Instant::fromEpochMilliseconds),
+            lastModificationTime = attributes.lastModifiedTime().toInstant().toKotlinInstant(),
         )
     }
 

--- a/core/jvm/src/files/FileSystemJvm.kt
+++ b/core/jvm/src/files/FileSystemJvm.kt
@@ -11,7 +11,6 @@ import java.io.FileOutputStream
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.nio.file.attribute.BasicFileAttributes
-import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlin.time.toKotlinInstant
 
@@ -53,7 +52,6 @@ private val mover: Mover by lazy {
     }
 }
 
-@OptIn(ExperimentalTime::class)
 @JvmField
 public actual val SystemFileSystem: FileSystem = object : SystemFileSystemImpl() {
 

--- a/core/jvm/src/files/FileSystemJvm.kt
+++ b/core/jvm/src/files/FileSystemJvm.kt
@@ -11,7 +11,6 @@ import java.io.FileOutputStream
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.nio.file.attribute.BasicFileAttributes
-import kotlin.time.Instant
 import kotlin.time.toKotlinInstant
 
 
@@ -95,7 +94,7 @@ public actual val SystemFileSystem: FileSystem = object : SystemFileSystemImpl()
             isDirectory = path.file.isDirectory,
             size = if (path.file.isFile) path.file.length() else -1L,
             createdAt = attributes.creationTime().toInstant().toKotlinInstant(),
-            lastModificationTime = attributes.lastModifiedTime().toInstant().toKotlinInstant(),
+            lastModifiedAt = attributes.lastModifiedTime().toInstant().toKotlinInstant(),
         )
     }
 

--- a/core/nativeNonApple/src/files/FileSystemNativeNonApple.kt
+++ b/core/nativeNonApple/src/files/FileSystemNativeNonApple.kt
@@ -8,12 +8,13 @@ package kotlinx.io.files
 import kotlinx.cinterop.*
 import kotlinx.io.IOException
 import platform.posix.*
+import kotlin.time.ExperimentalTime
 
 @OptIn(ExperimentalForeignApi::class)
 public actual val SystemTemporaryDirectory: Path
     get() = Path(getenv("TMPDIR")?.toKString() ?: getenv("TMP")?.toKString() ?: "")
 
-@OptIn(ExperimentalForeignApi::class, UnsafeNumber::class)
+@OptIn(ExperimentalForeignApi::class, UnsafeNumber::class, ExperimentalTime::class)
 internal actual fun metadataOrNullImpl(path: Path): FileMetadata? {
     memScoped {
         val struct_stat = alloc<stat>()
@@ -26,7 +27,9 @@ internal actual fun metadataOrNullImpl(path: Path): FileMetadata? {
         return FileMetadata(
             isRegularFile = isFile,
             isDirectory = (mode and S_IFMT) == S_IFDIR,
-            if (isFile) struct_stat.st_size.toLong() else -1L
+            size = if (isFile) struct_stat.st_size.toLong() else -1L,
+            createdAt = null,
+            updatedAt = null,
         )
     }
 }

--- a/core/nativeNonApple/src/files/FileSystemNativeNonApple.kt
+++ b/core/nativeNonApple/src/files/FileSystemNativeNonApple.kt
@@ -8,13 +8,12 @@ package kotlinx.io.files
 import kotlinx.cinterop.*
 import kotlinx.io.IOException
 import platform.posix.*
-import kotlin.time.ExperimentalTime
 
 @OptIn(ExperimentalForeignApi::class)
 public actual val SystemTemporaryDirectory: Path
     get() = Path(getenv("TMPDIR")?.toKString() ?: getenv("TMP")?.toKString() ?: "")
 
-@OptIn(ExperimentalForeignApi::class, UnsafeNumber::class, ExperimentalTime::class)
+@OptIn(ExperimentalForeignApi::class, UnsafeNumber::class)
 internal actual fun metadataOrNullImpl(path: Path): FileMetadata? {
     memScoped {
         val struct_stat = alloc<stat>()

--- a/core/nativeNonApple/src/files/FileSystemNativeNonApple.kt
+++ b/core/nativeNonApple/src/files/FileSystemNativeNonApple.kt
@@ -11,7 +11,7 @@ import platform.posix.*
 
 @OptIn(ExperimentalForeignApi::class)
 public actual val SystemTemporaryDirectory: Path
-    get() = Path(getenv("TMPDIR")?.toKString() ?: getenv("TMP")?.toKString() ?: "")
+    get() = Path(getenv("TMPDIR")?.toKString() ?: getenv("TMP")?.toKString() ?: "/tmp")
 
 @OptIn(ExperimentalForeignApi::class, UnsafeNumber::class)
 internal actual fun metadataOrNullImpl(path: Path): FileMetadata? {
@@ -29,7 +29,7 @@ internal actual fun metadataOrNullImpl(path: Path): FileMetadata? {
             isDirectory = (mode and S_IFMT) == S_IFDIR,
             size = if (isFile) struct_stat.st_size.toLong() else -1L,
             createdAt = null,
-            updatedAt = null,
+            lastModificationTime = null,
         )
     }
 }

--- a/core/nativeNonApple/src/files/FileSystemNativeNonApple.kt
+++ b/core/nativeNonApple/src/files/FileSystemNativeNonApple.kt
@@ -11,7 +11,7 @@ import platform.posix.*
 
 @OptIn(ExperimentalForeignApi::class)
 public actual val SystemTemporaryDirectory: Path
-    get() = Path(getenv("TMPDIR")?.toKString() ?: getenv("TMP")?.toKString() ?: "/tmp")
+    get() = Path(getenv("TMPDIR")?.toKString() ?: getenv("TMP")?.toKString() ?: "")
 
 @OptIn(ExperimentalForeignApi::class, UnsafeNumber::class)
 internal actual fun metadataOrNullImpl(path: Path): FileMetadata? {
@@ -28,8 +28,6 @@ internal actual fun metadataOrNullImpl(path: Path): FileMetadata? {
             isRegularFile = isFile,
             isDirectory = (mode and S_IFMT) == S_IFDIR,
             size = if (isFile) struct_stat.st_size.toLong() else -1L,
-            createdAt = null,
-            lastModificationTime = null,
         )
     }
 }

--- a/core/nodeFilesystemShared/src/files/FileSystemNodeJs.kt
+++ b/core/nodeFilesystemShared/src/files/FileSystemNodeJs.kt
@@ -82,8 +82,8 @@ public actual val SystemFileSystem: FileSystem = object : SystemFileSystemImpl()
                 isRegularFile = isFile,
                 isDirectory = (mode and fs.constants.S_IFMT) == fs.constants.S_IFDIR,
                 size = if (isFile) stat.size.toLong() else -1L,
-                createdAt = stat.ctimeMs.toInstant(),
-                updatedAt = stat.mtimeMs.toInstant(),
+                createdAt = null,
+                lastModificationTime = stat.mtimeMs.toInstantFromEpochMillis(),
             )
         }?.also {
             throw IOException("Stat failed for $path", it)
@@ -132,9 +132,10 @@ public actual open class FileNotFoundException actual constructor(
 ) : IOException(message)
 
 
-private fun Double.toInstant(): Instant {
+private fun Double.toInstantFromEpochMillis(): Instant {
+    val nanosInSeconds = 1_000_000_000
     val epoch = this * 0.001
     val seconds = epoch.toLong()
-    val nanos = (epoch - seconds).times(1e9).toLong()
+    val nanos = (epoch - seconds).times(nanosInSeconds).toLong()
     return Instant.fromEpochSeconds(seconds, nanos)
 }

--- a/core/nodeFilesystemShared/src/files/FileSystemNodeJs.kt
+++ b/core/nodeFilesystemShared/src/files/FileSystemNodeJs.kt
@@ -83,7 +83,7 @@ public actual val SystemFileSystem: FileSystem = object : SystemFileSystemImpl()
                 isDirectory = (mode and fs.constants.S_IFMT) == fs.constants.S_IFDIR,
                 size = if (isFile) stat.size.toLong() else -1L,
                 createdAt = null,
-                lastModificationTime = stat.mtimeMs.toInstantFromEpochMillis(),
+                lastModifiedAt = stat.mtimeMs.toInstantFromEpochMillis(),
             )
         }?.also {
             throw IOException("Stat failed for $path", it)

--- a/core/nodeFilesystemShared/src/node/fs.kt
+++ b/core/nodeFilesystemShared/src/node/fs.kt
@@ -70,7 +70,10 @@ internal external interface Fs {
  * Partial declaration of a class mirroring [node:fs.Stats](https://nodejs.org/api/fs.html#class-fsstats)
  */
 internal external interface Stats {
+    val atimeMs: Double
+    val ctimeMs: Double
     val mode: Int
+    val mtimeMs: Double
     val size: Int
     fun isDirectory(): Boolean
 }

--- a/core/nodeFilesystemShared/src/node/fs.kt
+++ b/core/nodeFilesystemShared/src/node/fs.kt
@@ -72,8 +72,8 @@ internal external interface Fs {
 internal external interface Stats {
     val atimeMs: Double
     val ctimeMs: Double
-    val mode: Int
     val mtimeMs: Double
+    val mode: Int
     val size: Int
     fun isDirectory(): Boolean
 }

--- a/core/src/jvmTest/kotlin/files/SmokeFileTest.jvm.kt
+++ b/core/src/jvmTest/kotlin/files/SmokeFileTest.jvm.kt
@@ -1,0 +1,3 @@
+package kotlinx.io.files
+
+internal actual val isJVM: Boolean = true

--- a/core/src/nativeTest/kotlin/files/SmokeFileTest.native.kt
+++ b/core/src/nativeTest/kotlin/files/SmokeFileTest.native.kt
@@ -1,0 +1,3 @@
+package kotlinx.io.files
+
+internal actual val isJVM: Boolean =false

--- a/core/src/nodeFilesystemSharedTest/kotlin/files/SmokeFileTest.nodeFilesystemShared.kt
+++ b/core/src/nodeFilesystemSharedTest/kotlin/files/SmokeFileTest.nodeFilesystemShared.kt
@@ -1,0 +1,3 @@
+package kotlinx.io.files
+
+internal actual val isJVM: Boolean = false

--- a/core/src/wasmTest/kotlin/files/SmokeFileTest.wasm.kt
+++ b/core/src/wasmTest/kotlin/files/SmokeFileTest.wasm.kt
@@ -1,0 +1,3 @@
+package kotlinx.io.files
+
+internal actual val isJVM: Boolean = false

--- a/core/wasmWasi/src/files/FileSystemWasm.kt
+++ b/core/wasmWasi/src/files/FileSystemWasm.kt
@@ -576,9 +576,9 @@ private class FileSource(private val fd: Fd) : RawSource {
 }
 
 private data class InternalMetadata(
-    val createdAt: Instant?,
     val filesize: Long,
     val filetype: FileType,
+    val createdAt: Instant?,
     val modifiedAt: Instant,
 )
 

--- a/core/wasmWasi/src/files/FileSystemWasm.kt
+++ b/core/wasmWasi/src/files/FileSystemWasm.kt
@@ -226,7 +226,7 @@ internal object WasiFileSystem : SystemFileSystemImpl() {
             isDirectory = isDirectory,
             size = filesize,
             createdAt = md.createdAt,
-            updatedAt = md.modifiedAt,
+            lastModificationTime = md.modifiedAt,
         )
     }
 
@@ -602,10 +602,9 @@ private fun metadataOrNullInternal(rootFd: Fd, path: Path, followSymlinks: Boole
         if (res != Errno.success) throw IOException(res.description)
 
         val modifiedAt = run {
-            val epoch = filestat.modificationTime * 1e-9
-            val seconds = epoch.toLong()
-            val nanos = (epoch - seconds) * 1e9
-            Instant.fromEpochSeconds(seconds, nanos.toLong())
+            val seconds = filestat.modificationTime / 1_000_000_000
+            val nanos = filestat.modificationTime % 1_000_000_000
+            Instant.fromEpochSeconds(seconds, nanos)
         }
         return InternalMetadata(
             createdAt = null,

--- a/core/wasmWasi/src/files/FileSystemWasm.kt
+++ b/core/wasmWasi/src/files/FileSystemWasm.kt
@@ -8,7 +8,6 @@ package kotlinx.io.files
 import kotlinx.io.*
 import kotlinx.io.wasi.*
 import kotlin.math.min
-import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlin.wasm.unsafe.UnsafeWasmMemoryApi
 import kotlin.wasm.unsafe.withScopedMemoryAllocator
@@ -215,7 +214,6 @@ internal object WasiFileSystem : SystemFileSystemImpl() {
         return FileSink(fd)
     }
 
-    @OptIn(ExperimentalTime::class)
     override fun metadataOrNull(path: Path): FileMetadata? {
         val (_, preOpen, relativePath) = PreOpens.resolvePreopenOrNull(path) ?: return null
         val md = metadataOrNullInternal(preOpen, relativePath, true) ?: return null
@@ -577,7 +575,6 @@ private class FileSource(private val fd: Fd) : RawSource {
     }
 }
 
-@OptIn(ExperimentalTime::class)
 private data class InternalMetadata(
     val createdAt: Instant?,
     val filesize: Long,
@@ -585,7 +582,7 @@ private data class InternalMetadata(
     val modifiedAt: Instant,
 )
 
-@OptIn(UnsafeWasmMemoryApi::class, ExperimentalTime::class)
+@OptIn(UnsafeWasmMemoryApi::class)
 private fun metadataOrNullInternal(rootFd: Fd, path: Path, followSymlinks: Boolean): InternalMetadata? {
     require(!path.isAbsolute) { "only relative paths are allowed, was: $path" }
     withScopedMemoryAllocator { allocator ->

--- a/core/wasmWasi/src/files/FileSystemWasm.kt
+++ b/core/wasmWasi/src/files/FileSystemWasm.kt
@@ -226,7 +226,7 @@ internal object WasiFileSystem : SystemFileSystemImpl() {
             isDirectory = isDirectory,
             size = filesize,
             createdAt = md.createdAt,
-            lastModificationTime = md.modifiedAt,
+            lastModifiedAt = md.modifiedAt,
         )
     }
 


### PR DESCRIPTION
Add support for file creation and modification timestamps in `FileMetadata` across platforms

This pull request closes issue #463 