### PR TITLE
Pass only relative paths into WASI FS API calls

### DIFF
--- a/core/wasmWasi/test/WasiFsTest.kt
+++ b/core/wasmWasi/test/WasiFsTest.kt
@@ -21,25 +21,26 @@ class WasiFsTest {
 
     @Test
     fun multiplePreOpens() {
-        fun checkPreOpen(forPath: String, expected: String?) {
+        fun checkPreOpen(forPath: String, expectedRoot: String?, expectedRelative: String? = null) {
             val preOpen = PreOpens.resolvePreopenOrNull(Path(forPath))
-            if (expected == null) {
+            if (expectedRoot == null) {
                 assertNull(preOpen)
             } else {
                 assertNotNull(preOpen)
-                assertEquals(Path(expected), preOpen.first.path)
+                assertEquals(Path(expectedRoot), preOpen.preOpenPath)
+                assertEquals(Path(expectedRelative!!), preOpen.relativePath)
             }
         }
 
-        checkPreOpen(forPath = "/data", expected = null)
-        checkPreOpen(forPath = "/tmp", expected = "/tmp")
-        checkPreOpen(forPath = "/tmp/a", expected = "/tmp")
-        checkPreOpen(forPath = "/var", expected = null)
-        checkPreOpen(forPath = "/var/what", expected = null)
-        checkPreOpen(forPath = "/var/log", expected = "/var/log")
-        checkPreOpen(forPath = "/tmp ", expected = null)
-        checkPreOpen(forPath = "/tmpry", expected = null)
-        checkPreOpen(forPath = "/var/logging", expected = null)
+        checkPreOpen(forPath = "/data", expectedRoot = null)
+        checkPreOpen(forPath = "/tmp", expectedRoot = "/tmp", expectedRelative = "")
+        checkPreOpen(forPath = "/tmp/a", expectedRoot = "/tmp", expectedRelative = "a")
+        checkPreOpen(forPath = "/var", expectedRoot = null)
+        checkPreOpen(forPath = "/var/what", expectedRoot = null)
+        checkPreOpen(forPath = "/var/log", expectedRoot = "/var/log", expectedRelative = "")
+        checkPreOpen(forPath = "/tmp ", expectedRoot = null)
+        checkPreOpen(forPath = "/tmpry", expectedRoot = null)
+        checkPreOpen(forPath = "/var/logging", expectedRoot = null)
     }
 
     @Test


### PR DESCRIPTION
It was never explicitly pronounced, but kinda implied, that WASI 0.1 FS-related API accepts only relative paths (relative to a provided file descriptor). In WASI 0.3 it is explicitly specified, but in recent NodeJS version, the same restriction was enacted for WASI 0.1 breaking our implementation.

To fix that, all paths are now explicitly converted to paths relative to a pre-open directory.

Things are a bit weird when it comes to symlinks as a corresponding WASI function accepts only relative paths for both a source and a target. We don't expose symlink-creation publicly, so for now it only limits what we can test.

Fixes #484 