### PR TITLE
Use IIFE to asynchronously load a module instead of globalThis

### DIFF
--- a/core/wasmJs/src/node/nodeModulesWasmJs.kt
+++ b/core/wasmJs/src/node/nodeModulesWasmJs.kt
@@ -7,55 +7,14 @@
 
 package kotlinx.io.node
 
-@JsFun("""
-    (globalThis.module = (typeof process !== 'undefined') && (process.release.name === 'node') ?
-        await import(/* webpackIgnore: true */'node:module') : void 0, () => {})
-""")
-internal external fun persistModule()
+@JsModule("node:buffer")
+internal actual external val buffer: BufferModule
 
-@JsFun("""() => { 
-    const importMeta = import.meta;
-    return globalThis.module.default.createRequire(importMeta.url);
-}
-""")
-internal external fun getRequire(): JsAny
+@JsModule("node:os")
+internal actual external val os: Os
 
-private val require = persistModule().let { getRequire() }
+@JsModule("node:path")
+internal actual external val path: Path
 
-@JsFun("""
-    (require, mod) => {
-         try {
-             let m = require(mod);
-             if (m) return m;
-             return null;
-         } catch (e) {
-             return null;
-         }
-    }
-""")
-internal external fun requireModule(require: JsAny, mod: String): JsAny?
-
-internal fun loadModule(name: String): JsAny {
-    val mod = requireModule(require, name) ?: throw UnsupportedOperationException("Module '$name' could not be imported")
-    return mod
-}
-
-internal actual val buffer: BufferModule by lazy {
-    @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
-    loadModule("buffer") as BufferModule
-}
-
-internal actual val os: Os  by lazy {
-    @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
-    loadModule("os") as Os
-}
-
-internal actual val path: Path by lazy {
-    @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
-    loadModule("path") as Path
-}
-
-internal actual val fs: Fs by lazy {
-    @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
-    loadModule("fs") as Fs
-}
+@JsModule("node:fs")
+internal actual external val fs: Fs

--- a/core/wasmJs/src/node/nodeModulesWasmJs.kt
+++ b/core/wasmJs/src/node/nodeModulesWasmJs.kt
@@ -7,14 +7,53 @@
 
 package kotlinx.io.node
 
-@JsModule("node:buffer")
-internal actual external val buffer: BufferModule
+internal actual val buffer: BufferModule by lazy {
+    @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
+    (loadBuffer() ?: throwModuleCannotBeImported("path")) as BufferModule
+}
 
-@JsModule("node:os")
-internal actual external val os: Os
+@JsFun("${LOAD_MODULE_PREFIX}buffer${LOAD_MODULE_POSTFIX}")
+private external fun loadBuffer(): JsAny?
 
-@JsModule("node:path")
-internal actual external val path: Path
+internal actual val os: Os by lazy {
+    @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
+    (loadOs() ?: throwModuleCannotBeImported("os")) as Os
+}
 
-@JsModule("node:fs")
-internal actual external val fs: Fs
+@JsFun("${LOAD_MODULE_PREFIX}os${LOAD_MODULE_POSTFIX}")
+private external fun loadOs(): JsAny?
+
+internal actual val path: Path by lazy {
+    @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
+    (loadPath() ?: throwModuleCannotBeImported("path")) as Path
+}
+
+@JsFun("${LOAD_MODULE_PREFIX}path${LOAD_MODULE_POSTFIX}")
+private external fun loadPath(): JsAny?
+
+internal actual val fs: Fs by lazy {
+    @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
+    (loadFs() ?: throwModuleCannotBeImported("fs")) as Fs
+}
+
+@JsFun("${LOAD_MODULE_PREFIX}fs${LOAD_MODULE_POSTFIX}")
+private external fun loadFs(): JsAny?
+
+private fun throwModuleCannotBeImported(name: String) {
+    throw UnsupportedOperationException("Module $name cannot be imported in this environment")
+}
+
+/*
+Wasm JsFun expect something invokeable, so we have to return an arrow function.
+IIFE which returns a function that returns an input parameter (resolved module).
+It helps us to work around the issue that we cannot use await import in non-async arrow functions.
+(
+    (module) => {
+        return () => module
+    }
+)(await import("module"))
+ */
+private const val LOAD_MODULE_PREFIX =
+    "((module) => () => module)(((typeof process !== 'undefined') && (process.release.name === 'node')) ? await import(/* webpackIgnore: true */'node:"
+
+private const val LOAD_MODULE_POSTFIX = "') : null)"


### PR DESCRIPTION
While `kotlinx-io` works only in nodejs, we can load builtins modules with standard `@JsModule` approach