### PR TITLE
Improve native `FileSource` and `FileSink`

### DIFF
--- a/build-logic/src/main/kotlin/kotlinx/io/conventions/kotlinx-io-multiplatform.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlinx/io/conventions/kotlinx-io-multiplatform.gradle.kts
@@ -105,6 +105,10 @@ kotlin {
                     group("mingw")
                     group("linux")
                 }
+                group("nativeNonMingw") {
+                    group("apple")
+                    group("unix")
+                }
             }
             group("nodeFilesystemShared") {
                 withJs()

--- a/core/mingw/src/files/FileSystemMingw.kt
+++ b/core/mingw/src/files/FileSystemMingw.kt
@@ -62,4 +62,4 @@ internal actual fun realpathImpl(path: String): String {
 }
 
 internal actual val DefaultOpenFlags: Int
-    get() = _O_BINARY
+    get() = _O_BINARY or _O_NOINHERIT

--- a/core/mingw/src/files/FileSystemMingw.kt
+++ b/core/mingw/src/files/FileSystemMingw.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
@@ -60,3 +60,6 @@ internal actual fun realpathImpl(path: String): String {
         return buffer.toKString()
     }
 }
+
+internal actual val DefaultOpenFlags: Int
+    get() = _O_BINARY

--- a/core/native/src/files/FileSystemNative.kt
+++ b/core/native/src/files/FileSystemNative.kt
@@ -1,18 +1,16 @@
 /*
- * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
  */
 
 package kotlinx.io.files
 
-import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.toKString
 import kotlinx.io.IOException
 import kotlinx.io.RawSink
 import kotlinx.io.RawSource
 import platform.posix.*
-import kotlin.experimental.ExperimentalNativeApi
 
 @OptIn(ExperimentalForeignApi::class)
 public actual val SystemFileSystem: FileSystem = object : SystemFileSystemImpl() {
@@ -73,20 +71,27 @@ public actual val SystemFileSystem: FileSystem = object : SystemFileSystemImpl()
     }
 
     override fun source(path: Path): RawSource {
-        val openFile: CPointer<FILE>? = fopen(path.path, "rb")
-        if (openFile == null) {
+        val openFd = open(path.path, O_RDONLY or DefaultOpenFlags)
+        if (openFd < 0) {
             if (errno == ENOENT) {
                 throw FileNotFoundException("File does not exist: $path")
             }
             throw IOException("Failed to open $path with ${strerror(errno)?.toKString()}")
         }
-        return FileSource(openFile)
+        return FileSource(openFd)
     }
 
     override fun sink(path: Path, append: Boolean): RawSink {
-        val openFile: CPointer<FILE> = fopen(path.path, if (append) "ab" else "wb")
-            ?: throw IOException("Failed to open $path with ${strerror(errno)?.toKString()}")
-        return FileSink(openFile)
+        val openFd = open(
+            path.path,
+            O_WRONLY or O_CREAT or DefaultOpenFlags
+                    or (if (append) O_APPEND else O_TRUNC),
+            PermissionDefault
+        )
+        if (openFd < 0) {
+            throw IOException("Failed to open $path with ${strerror(errno)?.toKString()}")
+        }
+        return FileSink(openFd)
     }
 
     override fun list(directory: Path): Collection<Path> {
@@ -118,8 +123,13 @@ public actual open class FileNotFoundException actual constructor(
     message: String?
 ) : IOException(message)
 
+// 666 in octal, rw for all (owner, group and others).
+internal const val PermissionDefault: UShort = 0b110110110u
+
 // 777 in octal, rwx for all (owner, group and others).
-internal const val PermissionAllowAll: UShort = 511u
+internal const val PermissionAllowAll: UShort = 0b111111111u
+
+internal expect val DefaultOpenFlags: Int
 
 internal expect class OpaqueDirEntry : AutoCloseable {
     fun readdir(): String?

--- a/core/native/src/files/PathsNative.kt
+++ b/core/native/src/files/PathsNative.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 JetBrains s.r.o. and respective authors and developers.
+ * Copyright 2017-2026 JetBrains s.r.o. and respective authors and developers.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENCE file.
  */
 
@@ -9,6 +9,7 @@ package kotlinx.io.files
 
 import kotlinx.cinterop.*
 import kotlinx.io.*
+import kotlinx.io.unsafe.UnsafeBufferOperations
 import platform.posix.*
 
 /*
@@ -71,59 +72,49 @@ private fun throwIOExceptionForErrno(operation: String): Nothing {
 }
 
 internal class FileSource(
-    private val file: CPointer<FILE>
+    private val fd: Int
 ) : RawSource {
     private var closed = false
 
+    @OptIn(UnsafeIoApi::class)
     override fun readAtMostTo(
         sink: Buffer,
         byteCount: Long
     ): Long {
-        val temporaryBuffer = ByteArray(byteCount.toInt())
-
-        // Copy bytes from the file to the segment.
-        val bytesRead = temporaryBuffer.usePinned { pinned ->
-            variantFread(pinned.addressOf(0), byteCount.toUInt(), file).toLong()
+        val bytesRead = UnsafeBufferOperations.writeToTail(sink, 1) { bytes, startIndex, endIndex ->
+            val toRead = minOf((endIndex - startIndex).toLong(), byteCount)
+            val bytesRead = bytes.usePinned {
+                @OptIn(UnsafeNumber::class)
+                @Suppress("REDUNDANT_CALL_OF_CONVERSION_METHOD") // https://youtrack.jetbrains.com/issue/KT-81896
+                read(fd, it.addressOf(startIndex), toRead.convert()).toInt()
+            }
+            if (bytesRead == -1) {
+                throwIOExceptionForErrno("read")
+            }
+            bytesRead
         }
 
-        sink.write(temporaryBuffer, 0, bytesRead.toInt())
-
-        return when {
-            bytesRead == byteCount -> bytesRead
-            feof(file) != 0 -> if (bytesRead == 0L) -1L else bytesRead
-            ferror(file) != 0 -> throwIOExceptionForErrno("write")
-            else -> bytesRead
+        return when (bytesRead) {
+            0 -> -1L
+            else -> bytesRead.toLong()
         }
     }
 
     override fun close() {
         if (closed) return
         closed = true
-        if (fclose(file) != 0) {
-            throwIOExceptionForErrno("fclose")
+        if (close(fd) != 0) {
+            throwIOExceptionForErrno("close")
         }
     }
 }
 
-@OptIn(UnsafeNumber::class)
-internal fun variantFread(
-    target: CPointer<ByteVarOf<Byte>>,
-    byteCount: UInt,
-    file: CPointer<FILE>
-): UInt = fread(target, 1u, byteCount.convert(), file).convert()
-
-@OptIn(UnsafeNumber::class)
-internal fun variantFwrite(
-    source: CPointer<ByteVar>,
-    byteCount: UInt,
-    file: CPointer<FILE>
-): UInt = fwrite(source, 1u, byteCount.convert(), file).convert()
-
 internal class FileSink(
-    private val file: CPointer<FILE>
+    private val fd: Int
 ) : RawSink {
     private var closed = false
 
+    @OptIn(UnsafeIoApi::class)
     override fun write(
         source: Buffer,
         byteCount: Long
@@ -132,27 +123,33 @@ internal class FileSink(
         require(source.size >= byteCount) { "source.size=${source.size} < byteCount=$byteCount" }
         check(!closed) { "closed" }
 
-        val allContent = source.readByteArray(byteCount.toInt())
-        // Copy bytes from that segment into the file.
-        val bytesWritten = allContent.usePinned { pinned ->
-            variantFwrite(pinned.addressOf(0), byteCount.toUInt(), file).toLong()
-        }
-        if (bytesWritten < byteCount) {
-            throwIOExceptionForErrno("file write")
+        var remaining = byteCount
+        while (remaining > 0) {
+            remaining -= UnsafeBufferOperations.readFromHead(source) { bytes, startIndex, endIndex ->
+                val toWrite = minOf((endIndex - startIndex).toLong(), remaining)
+                val bytesWritten = bytes.usePinned {
+                    @OptIn(UnsafeNumber::class)
+                    @Suppress("REDUNDANT_CALL_OF_CONVERSION_METHOD") // https://youtrack.jetbrains.com/issue/KT-81896
+                    write(fd, it.addressOf(startIndex), toWrite.convert()).toInt()
+                }
+                if (bytesWritten == -1) {
+                    throwIOExceptionForErrno("write")
+                }
+                bytesWritten
+            }
         }
     }
 
-    override fun flush() {
-        if (fflush(file) != 0) {
-            throwIOExceptionForErrno("fflush")
-        }
-    }
+    /**
+     * This method does nothing as writes are sent directly to the file.
+     */
+    override fun flush() = Unit
 
     override fun close() {
         if (closed) return
         closed = true
-        if (fclose(file) != 0) {
-            throwIOExceptionForErrno("fclose")
+        if (close(fd) != 0) {
+            throwIOExceptionForErrno("close")
         }
     }
 }

--- a/core/nativeNonMingw/src/files/FileSystemNativeNonMingw.kt
+++ b/core/nativeNonMingw/src/files/FileSystemNativeNonMingw.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.io.files
+
+import platform.posix.O_CLOEXEC
+
+internal actual val DefaultOpenFlags: Int
+    get() = O_CLOEXEC


### PR DESCRIPTION
- Switch to unbuffered I/O (open/read/write)
- Use UnsafeBufferOperations for zero-copy segment access
- Enable `O_CLOEXEC` on Unix platforms

Closes #438, Closes #493 