### PR TITLE
Use bswap intrinsics for reverseBytes() on native targets to better utilize hardware

### DIFF
--- a/core/native/src/UtilsNative.kt
+++ b/core/native/src/UtilsNative.kt
@@ -5,6 +5,10 @@
 
 package kotlinx.io
 
-internal actual fun Short.reverseBytes(): Short = reverseBytesCommon()
-internal actual fun Int.reverseBytes(): Int = reverseBytesCommon()
-internal actual fun Long.reverseBytes(): Long = reverseBytesCommon()
+import platform.builtin.builtin_bswap16
+import platform.builtin.builtin_bswap32
+import platform.builtin.builtin_bswap64
+
+internal actual fun Short.reverseBytes(): Short = builtin_bswap16(this)
+internal actual fun Int.reverseBytes(): Int = builtin_bswap32(this)
+internal actual fun Long.reverseBytes(): Long = builtin_bswap64(this)


### PR DESCRIPTION
Kotlin/Native has support for GCC/Clang builtins, including the various `bswap` intrinsics which may compile down to `BSWAPnn` instructions on x86 directly (and `REVnn` on aarch64).
These intrinsics should be used to implement the `reverseByte()` extensions on Native targets to get the maximum hardware support possible, since common implementations may either be slower or can't be optimized that well.