### PR TITLE
intrinsic accelerated ASCII dominant content

### DIFF
--- a/benchmarks/src/jvmMain/kotlin/ReadStringUtf8GateBenchmark.kt
+++ b/benchmarks/src/jvmMain/kotlin/ReadStringUtf8GateBenchmark.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.io.benchmarks
+
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.Param
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.io.Buffer
+import kotlinx.io.readString
+
+/**
+ * Compares the common readString() UTF-8 decoder against the JVM readString(charset) overload
+ * across payload sizes, to pick the JDK version gate for the multi-release JAR specialization
+ * discussed in https://github.com/Kotlin/kotlinx-io/issues/515.
+ *
+ * Payloads are ASCII JSON sliced to the exact byte count; "-mixed" additionally contains
+ * 2-3 byte characters and an emoji. Both benchmarks include identical Buffer staging cost.
+ */
+@State(Scope.Benchmark)
+open class ReadStringUtf8GateBenchmark {
+    @Param("16", "128", "960", "16384", "102400", "16384-mixed")
+    var payload: String = ""
+
+    private var bytes: ByteArray = ByteArray(0)
+
+    @Setup
+    fun setup() {
+        val size = payload.removeSuffix("-mixed").toInt()
+        bytes = if (payload.endsWith("-mixed")) mixedJson(size) else asciiJson(size)
+    }
+
+    @Benchmark
+    fun common(): String = Buffer().apply { write(bytes) }.readString()
+
+    @Benchmark
+    fun jvmOverload(): String = Buffer().apply { write(bytes) }.readString(Charsets.UTF_8)
+}
+
+private fun jsonObject(id: Int): String = buildString {
+    append("{\"id\":").append(id)
+    for (f in 1..29) {
+        append(",\"field_").append(f).append("\":")
+        when (f % 4) {
+            0 -> append(id * 31 + f)
+            1 -> append("\"value_").append(id).append('_').append(f).append('"')
+            2 -> append((id + f) % 2 == 0)
+            else -> append(id % 100).append('.').append(f)
+        }
+    }
+    append('}')
+}
+
+private fun asciiJson(size: Int): ByteArray {
+    val sb = StringBuilder("[")
+    var id = 0
+    while (sb.length <= size) {
+        if (id > 0) sb.append(',')
+        sb.append(jsonObject(id++))
+    }
+    return sb.substring(0, size).encodeToByteArray()
+}
+
+private fun mixedJson(size: Int): ByteArray {
+    val sb = StringBuilder()
+    var byteLength = 0
+    var id = 0
+    while (byteLength < size) {
+        val chunk = "{\"città\":\"München_$id\",\"note\":\"日本語テキスト 🚀\"," +
+                jsonObject(id).removePrefix("{") + ","
+        sb.append(chunk)
+        byteLength += chunk.encodeToByteArray().size
+        id++
+    }
+    var s = sb.toString()
+    var encoded = s.encodeToByteArray()
+    while (encoded.size > size) {
+        s = s.substring(0, s.length - 1)
+        encoded = s.encodeToByteArray()
+    }
+    // Pad with spaces at the byte level to hit the exact size; the result stays valid UTF-8.
+    val out = encoded.copyOf(size)
+    out.fill(' '.code.toByte(), encoded.size, size)
+    return out
+}

--- a/benchmarks/src/jvmMain/kotlin/Utf8DensitySweepBenchmark.kt
+++ b/benchmarks/src/jvmMain/kotlin/Utf8DensitySweepBenchmark.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package kotlinx.io.benchmarks
+
+import kotlinx.benchmark.Benchmark
+import kotlinx.benchmark.Param
+import kotlinx.benchmark.Scope
+import kotlinx.benchmark.Setup
+import kotlinx.benchmark.State
+import kotlinx.io.Buffer
+import kotlinx.io.readString
+
+/**
+ * Measures readString() over a fixed 16 KiB payload while sweeping the density of
+ * non-ASCII characters, to locate the crossover between the JDK decoder's bulk-ASCII
+ * advantage and its cost on scattered multi-byte content.
+ *
+ * Kinds: "ascii" is a pure-ASCII baseline; "latin-N" replaces N% of characters with
+ * a 2-byte char (U+00E9, stays Latin-1-compact on the JVM); "cjk-N" uses a 3-byte
+ * char (U+65E5, forces UTF-16 storage). Characters are scattered evenly.
+ */
+@State(Scope.Benchmark)
+open class Utf8DensitySweepBenchmark {
+    @Param("ascii", "latin-2", "latin-10", "latin-33", "latin-100", "cjk-2", "cjk-10", "cjk-33", "cjk-100")
+    var kind: String = ""
+
+    private var bytes: ByteArray = ByteArray(0)
+
+    @Setup
+    fun setup() {
+        bytes = sweepPayload(kind, 16384)
+    }
+
+    @Benchmark
+    fun readString(): String = Buffer().apply { write(bytes) }.readString()
+}
+
+private fun sweepPayload(kind: String, size: Int): ByteArray {
+    fun baseChar(i: Int): Char = if (i % 8 == 7) ' ' else ('a' + (i * 7) % 26)
+
+    val everyNth: Int
+    val replacement: Char
+    if (kind == "ascii") {
+        everyNth = 0
+        replacement = ' '
+    } else {
+        val parts = kind.split('-')
+        replacement = if (parts[0] == "latin") 'é' else '日'
+        everyNth = 100 / parts[1].toInt()
+    }
+
+    val sb = StringBuilder()
+    var byteLength = 0
+    var i = 0
+    while (byteLength < size) {
+        val c = if (everyNth > 0 && i % everyNth == 0) replacement else baseChar(i)
+        sb.append(c)
+        byteLength += if (c.code < 0x80) 1 else if (c.code < 0x800) 2 else 3
+        i++
+    }
+    var s = sb.toString()
+    var encoded = s.encodeToByteArray()
+    while (encoded.size > size) {
+        s = s.substring(0, s.length - 1)
+        encoded = s.encodeToByteArray()
+    }
+    // Pad with spaces at the byte level to hit the exact size; the result stays valid UTF-8.
+    val out = encoded.copyOf(size)
+    out.fill(' '.code.toByte(), encoded.size, size)
+    return out
+}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -7,6 +7,9 @@
 
 import org.gradle.internal.os.OperatingSystem
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmCompilation
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     id("kotlinx-io-multiplatform")
@@ -98,4 +101,98 @@ tasks.named("wasmWasiNodeTest") {
 
 animalsniffer {
     annotation = "kotlinx.io.files.AnimalSnifferIgnore"
+}
+
+// Multi-release jar support: Kotlin classes from jvm/src9 are compiled for JDK 9
+// and packed into META-INF/versions/9, overriding their base counterparts from jvm/src
+// when the jar is loaded by a JDK 9+ runtime. See https://github.com/Kotlin/kotlinx-io/issues/515.
+val mrjToolchain = libs.versions.multi.release.toolchain.get()
+
+fun KotlinJvmCompilation.setupJava9CompileTasks() {
+    compileTaskProvider.configure {
+        this as KotlinJvmCompile
+
+        kotlinJavaToolchain.toolchain.use(javaToolchains.launcherFor {
+            languageVersion.set(JavaLanguageVersion.of(mrjToolchain))
+        })
+
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_9)
+            // TODO: don't use -Xjdk-release as it cause miscompilation, see KT-72880
+        }
+    }
+
+    compileJavaTaskProvider?.configure {
+        targetCompatibility = "9"
+        sourceCompatibility = "9"
+    }
+}
+
+kotlin {
+    jvm {
+        compilations {
+            // it has to be <something>Main, see KotlinSourceSet.configureSourceSet
+            val jvm9Main by creating {
+                associateWith(getByName("main"))
+
+                defaultSourceSet {
+                    kotlin.srcDir("jvm/src9")
+                }
+
+                setupJava9CompileTasks()
+            }
+
+            create("jvm9Test") {
+                associateWith(jvm9Main)
+                associateWith(getByName("test"))
+
+                defaultSourceSet {
+                    kotlin.srcDir("jvm/test9")
+
+                    dependencies {
+                        implementation(kotlin("test-junit5"))
+                    }
+                }
+
+                setupJava9CompileTasks()
+
+                val jvm9TestTask = tasks.register<Test>("jvm9Test") {
+                    group = "verification"
+
+                    // jvm9Main classes must precede the main compilation's on the classpath
+                    // so they shadow their base counterparts, like META-INF/versions/9 entries
+                    // shadow base entries in the packaged multi-release jar.
+                    classpath = files(jvm9Main.output.allOutputs) +
+                            compileDependencyFiles + runtimeDependencyFiles + output.allOutputs
+                    testClassesDirs = output.classesDirs
+
+                    javaLauncher.set(javaToolchains.launcherFor {
+                        languageVersion.set(JavaLanguageVersion.of(mrjToolchain))
+                    })
+
+                    useJUnitPlatform()
+                }
+                tasks.named("allTests").configure {
+                    dependsOn(jvm9TestTask)
+                }
+            }
+
+            tasks.named<Jar>("jvmJar") {
+                from(jvm9Main.output.allOutputs) {
+                    into("META-INF/versions/9")
+                }
+            }
+        }
+    }
+}
+
+kover {
+    currentProject {
+        instrumentation {
+            disabledForTestTasks.add("jvm9Test")
+        }
+        sources {
+            excludedSourceSets.addAll("jvm9Main", "jvm9Test")
+        }
+    }
 }

--- a/core/common/src/Utf8.kt
+++ b/core/common/src/Utf8.kt
@@ -611,13 +611,14 @@ private fun Buffer.commonReadUtf8(byteCount: Long): String {
         if (segment.size >= byteCount) {
             var result = ""
             ctx.withData(segment) { data, pos, limit ->
-                result = data.commonToUtf8String(pos, min(limit, pos + byteCount.toInt()))
+                result = decodeUtf8(data, pos, min(limit, pos + byteCount.toInt()))
                 skip(byteCount)
                 return result
             }
         }
         // If the string spans multiple segments, delegate to readBytes()
-        return readByteArray(byteCount.toInt()).commonToUtf8String()
+        val bytes = readByteArray(byteCount.toInt())
+        return decodeUtf8(bytes, 0, bytes.size)
     }
     error("Unreacheable")
 }

--- a/core/common/src/internal/-Utf8.kt
+++ b/core/common/src/internal/-Utf8.kt
@@ -38,6 +38,16 @@ internal fun ByteArray.commonToUtf8String(beginIndex: Int = 0, endIndex: Int = s
     return chars.concatToString(0, length)
 }
 
+/**
+ * Decodes bytes in the range `[beginIndex..endIndex)` of [source] as a UTF-8 encoded string,
+ * substituting ill-formed byte sequences with replacement characters (`U+FFFD`).
+ *
+ * On most platforms, this delegates to [commonToUtf8String]. On JVM runtimes newer than JDK 8,
+ * a specialized implementation backed by the JDK's intrinsified UTF-8 decoder is loaded from
+ * the multi-release jar instead (see `Utf8Intrinsics` in the `jvm/src9` source root).
+ */
+internal expect fun decodeUtf8(source: ByteArray, beginIndex: Int, endIndex: Int): String
+
 internal const val REPLACEMENT_BYTE: Byte = '?'.code.toByte()
 internal const val REPLACEMENT_CHARACTER: Char = '\ufffd'
 internal const val REPLACEMENT_CODE_POINT: Int = REPLACEMENT_CHARACTER.code

--- a/core/js/src/internal/Utf8Js.kt
+++ b/core/js/src/internal/Utf8Js.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2017-2026 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENCE file.
+ */
+
+package kotlinx.io.internal
+
+internal actual fun decodeUtf8(source: ByteArray, beginIndex: Int, endIndex: Int): String =
+    source.commonToUtf8String(beginIndex, endIndex)

--- a/core/jvm/src/internal/Utf8Intrinsics.kt
+++ b/core/jvm/src/internal/Utf8Intrinsics.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2026 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENCE file.
+ */
+
+package kotlinx.io.internal
+
+internal actual fun decodeUtf8(source: ByteArray, beginIndex: Int, endIndex: Int): String =
+    Utf8Intrinsics.decodeUtf8ToString(source, beginIndex, endIndex)
+
+/**
+ * UTF-8 decoding implementation selected through the multi-release jar mechanism.
+ *
+ * This is the base variant loaded on JDK 8 and Android; it delegates to the common decoder.
+ * On JDK 9 and newer runtimes, the class of the same name from `META-INF/versions/9`
+ * (compiled from the `jvm/src9` source root) is loaded instead.
+ *
+ * Both variants must declare identical signatures.
+ */
+internal object Utf8Intrinsics {
+    fun decodeUtf8ToString(source: ByteArray, beginIndex: Int, endIndex: Int): String =
+        source.commonToUtf8String(beginIndex, endIndex)
+}

--- a/core/jvm/src9/internal/Utf8Intrinsics.kt
+++ b/core/jvm/src9/internal/Utf8Intrinsics.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017-2026 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENCE file.
+ */
+
+package kotlinx.io.internal
+
+/**
+ * JDK 9+ variant of `Utf8Intrinsics`, packed into `META-INF/versions/9` of the multi-release jar
+ * and shadowing the base variant from `jvm/src` on modern runtimes.
+ *
+ * Decoding through the `String` constructor engages the JDK's intrinsified UTF-8 decoder,
+ * which scans and copies ASCII-dominant content in bulk instead of decoding it byte by byte
+ * (3-4x faster and half the allocations for typical JSON/HTML payloads, see
+ * https://github.com/Kotlin/kotlinx-io/issues/515). For ill-formed sequences it follows
+ * the Unicode "maximal subpart" convention, which may substitute a different number of
+ * replacement characters than the common decoder.
+ *
+ * Signatures must stay identical to the base variant.
+ */
+internal object Utf8Intrinsics {
+    fun decodeUtf8ToString(source: ByteArray, beginIndex: Int, endIndex: Int): String =
+        String(source, beginIndex, endIndex - beginIndex, Charsets.UTF_8)
+}

--- a/core/jvm/test9/ReadStringJdk9Test.kt
+++ b/core/jvm/test9/ReadStringJdk9Test.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017-2026 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENCE file.
+ */
+
+package kotlinx.io
+
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Exercises [readString] against the JDK 9+ `Utf8Intrinsics` variant from `jvm/src9`,
+ * which the `jvm9Test` task puts ahead of the base variant on the classpath, mirroring
+ * how `META-INF/versions/9` entries shadow base entries in the packaged multi-release jar.
+ */
+class ReadStringJdk9Test {
+    private fun bufferOf(bytes: ByteArray): Buffer = Buffer().apply { write(bytes) }
+
+    @Test
+    fun fastPathIsActive() {
+        // Discriminates the two Utf8Intrinsics variants: for the overlong encoding 0xC0 0xAF
+        // the JDK decoder emits two replacement characters (Unicode maximal subpart convention)
+        // while the common decoder emits one. If this fails, the base variant was loaded and
+        // the JDK 9+ specialization is not being tested.
+        assertEquals("��", bufferOf(byteArrayOf(-64, -81)).readString())
+    }
+
+    @Test
+    fun asciiSingleSegment() {
+        val text = "The quick brown fox jumps over the lazy dog: 0123456789"
+        assertEquals(text, bufferOf(text.encodeToByteArray()).readString())
+    }
+
+    @Test
+    fun multiByteContent() {
+        val text = "München Straße 日本語のテキスト 🚀 done"
+        assertEquals(text, bufferOf(text.encodeToByteArray()).readString())
+    }
+
+    @Test
+    fun multiSegmentWithCharsStraddlingSegmentBoundary() {
+        // 8191 bytes of ASCII place the two-byte 'é' across the default segment boundary.
+        val text = "a".repeat(8191) + "é" + "b".repeat(8192) + "☃" + "c".repeat(100)
+        assertEquals(text, bufferOf(text.encodeToByteArray()).readString())
+    }
+
+    @Test
+    fun byteCountBoundedRead() {
+        val buffer = bufferOf("hello, world".encodeToByteArray())
+        assertEquals("hello", buffer.readString(5L))
+        assertEquals(", world", buffer.readString())
+    }
+
+    @Test
+    fun emptyString() {
+        assertEquals("", Buffer().readString())
+    }
+
+    @Test
+    fun malformedSequencesFollowJdkConvention() {
+        val cases = listOf(
+            byteArrayOf(-64, -81), // overlong '/' (0xC0 0xAF)
+            byteArrayOf(-32, -128, -81), // overlong, three-byte form (0xE0 0x80 0xAF)
+            byteArrayOf(-19, -96, -128), // CESU-8 high surrogate (0xED 0xA0 0x80)
+            byteArrayOf(-61), // truncated two-byte sequence
+            byteArrayOf(-30, -126), // truncated three-byte sequence
+            byteArrayOf(-16, -112, -115), // truncated four-byte sequence
+            byteArrayOf(-128), // lone continuation byte
+            byteArrayOf(65, -128, -128, 66), // continuation bytes between ASCII
+            byteArrayOf(-12, -112, -128, -128), // code point above U+10FFFF (0xF4 0x90 0x80 0x80)
+        )
+        for (bytes in cases) {
+            assertEquals(
+                String(bytes, Charsets.UTF_8),
+                bufferOf(bytes).readString(),
+                "bytes: ${bytes.joinToString()}",
+            )
+        }
+    }
+
+    @Test
+    fun randomBytesMatchJdkDecoder() {
+        val random = Random(20260719)
+        repeat(1000) {
+            val bytes = random.nextBytes(random.nextInt(0, 512))
+            assertEquals(String(bytes, Charsets.UTF_8), bufferOf(bytes).readString())
+        }
+    }
+
+    @Test
+    fun randomValidStringsRoundTrip() {
+        val random = Random(715)
+        repeat(1000) {
+            val text = buildString {
+                repeat(random.nextInt(0, 64)) {
+                    when (random.nextInt(4)) {
+                        0 -> append('a' + random.nextInt(26))
+                        1 -> append('é')
+                        2 -> append('日')
+                        else -> append("🚀")
+                    }
+                }
+            }
+            assertEquals(text, Buffer().apply { writeString(text) }.readString())
+        }
+    }
+}

--- a/core/native/src/internal/Utf8Native.kt
+++ b/core/native/src/internal/Utf8Native.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2017-2026 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENCE file.
+ */
+
+package kotlinx.io.internal
+
+internal actual fun decodeUtf8(source: ByteArray, beginIndex: Int, endIndex: Int): String =
+    source.commonToUtf8String(beginIndex, endIndex)

--- a/core/wasm/src/internal/Utf8Wasm.kt
+++ b/core/wasm/src/internal/Utf8Wasm.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2017-2026 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENCE file.
+ */
+
+package kotlinx.io.internal
+
+internal actual fun decodeUtf8(source: ByteArray, beginIndex: Int, endIndex: Int): String =
+    source.commonToUtf8String(beginIndex, endIndex)

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,3 +9,4 @@ kotlin.code.style=official
 org.gradle.jvmargs=-Xmx4G
 nativeBenchmarksEnabled=true
 kotlin.mpp.applyDefaultHierarchyTemplate=false
+kotlin.build.archivesTaskOutputAsFriendModule=false


### PR DESCRIPTION
**Motivation**

The common no-arg Source.readString() decodes UTF-8 through commonToUtf8String, staging a CharArray and decoding byte by byte. On modern JVMs, String(bytes, offset, length, UTF_8) is intrinsic-accelerated (compact strings): ASCII-dominant content (typical JSON, HTML, protocol text) decodes in bulk, 3-4.5x faster with about half the allocations.

**Solution**

Per the discussion in #515, the UTF-8 decode path is specialized through the multi-release jar mechanism, reusing the jvm9Main/jvm9Test compilation setup from the array-exts branch:

- commonReadUtf8 now decodes through an internal expect fun decodeUtf8; all non-JVM actuals delegate to the existing common decoder unchanged.
- The JVM actual routes through Utf8Intrinsics: the base variant (JDK 8, Android) delegates to the common decoder, while a jvm/src9 variant packed into META-INF/versions/9 uses String(bytes, offset, length, UTF_8).
- No public API changes; ABI dumps are untouched.

Behavior note: on JDK 9+, ill-formed UTF-8 sequences are substituted following the JDK decoder's Unicode "maximal subpart" convention, which for some inputs (e.g. the overlong encoding 0xC0 0xAF) emits a different number of U+FFFD than the common decoder (two instead of one). This is the convention requested in #301. All well-formed input decodes identically; JDK 8 and non-JVM targets are unchanged.

**Benchmarks**
(the table above, plus:) JDK 8 stays on the base path and is unchanged within noise. Non-ASCII-heavy content ("mixed") pays 6–10% on JDK 9+; ASCII-dominant payloads gain 2–4.9x from 128 B up. An earlier exploration also confirmed JDK 9 itself never regresses (Zulu 9.0.7 under Rosetta with a matched control: 1.1–2.1x wins), and the no-arg path now slightly outperforms the JVM readString(charset) overload.

| Payload | JDK 8 | JDK 11 | JDK 21 | JDK 26 |
|---|---|---|---|---|
| 16 B | 15.7 → 15.8 (1.0x) | 16.5 → 14.5 (1.14x) | 15.8 → 12.5 (1.26x) | 15.4 → 13.8 (1.12x) |
| 128 B | 40.7 → 40.4 (1.0x) | 41.8 → 20.8 (2.0x) | 40.6 → 18.2 (2.2x) | 40.4 → 19.7 (2.1x) |
| 960 B | 234.6 → 235.7 (1.0x) | 213.6 → 48.0 (4.5x) | 224.9 → 45.6 (4.9x) | 222.1 → 46.5 (4.8x) |
| 16 KB | 4,651 → 4,686 (1.0x) | 4,215 → 1,411 (3.0x) | 4,561 → 1,401 (3.3x) | 4,586 → 1,433 (3.2x) |
| 100 KB | 26,284 → 27,442 (1.0x) | 26,742 → 8,283 (3.2x) | 26,520 → 8,520 (3.1x) | 26,694 → 8,528 (3.1x) |
| 16 KB mixed | 5,153 → 5,190 (1.0x) | 5,240 → 5,805 (0.90x) | 5,331 → 5,646 (0.94x) | 5,326 → 5,743 (0.93x) |

It seems that when emoji is included (mixed) there is a small penalty. Probably because this forces the result out of compact Latin-1 storage into UTF-16. I dug deeper to see how much of the string needs to be non-ASCII to hit the bad-case. Results:

| Non-ASCII density | JDK 11 | JDK 17 | JDK 21 |
|---|---|---|---|
| 0% (pure ASCII) | 4,195 → 1,401 (3.0x) | — | 4,545 → 1,391 (3.3x) |
| 2% Latin | 4,672 → 16,860 (**0.28x**) | 4,475 → 16,634 (**0.27x**) | 4,843 → 4,863 (1.00x) |
| 10% Latin | 6,855 → 15,709 (**0.44x**) | 6,932 → 15,684 (**0.44x**) | 7,183 → 10,841 (0.66x) |
| 33% Latin | 11,499 → 13,150 (0.87x) | — | 11,822 → 9,717 (1.22x) |
| 100% Latin | 5,839 → 5,376 (1.09x) | — | 5,683 → 4,353 (1.31x) |
| 2% CJK | 4,794 → 5,285 (0.91x) | — | 5,128 → 5,220 (0.98x) |
| 10% CJK | 6,797 → 6,603 (1.03x) | — | 7,149 → 7,286 (0.98x) |
| 33% CJK | 11,195 → 9,202 (1.22x) | — | 11,262 → 10,800 (1.04x) |
| 100% CJK | 8,067 → 9,496 (0.85x) | — | 7,343 → 8,357 (0.88x) |

Looks like sparse non-ASCII characters pay a performance penalty if below JVM 21. 

I am not sure, if I should **gate at JVM 21+** or only do this path if **pure ASCII:**

| | `versions/21` gate | hybrid ASCII probe (stays `versions/9`) |
|---|---|---|
| ASCII on JDK 11/17 | 1.0x — win forfeited | ~2.5–3x |
| ASCII on JDK 21+ | 3.3x | ~2.8–3x (probe overhead) |
| Sparse Latin (European text) | 0.66–1.0x on 21+ | 1.0x by construction |
| CJK / emoji | 0.88–1.04x on 21+ | 1.0x by construction |
| Dense Latin (100%) | 1.31x on 21+ | 1.0x — win forfeited |]
| Sensitivity to JDK decoder quality | still exposed (JDK 22+ could shift again) | none — JDK path only ever sees ASCII |
| Code | trivial (dir rename + toolchain bump) | +probe & its tests (~15 lines) |

Hybrid would look like this:

```kotlin
fun decodeUtf8ToString(source: ByteArray, beginIndex: Int, endIndex: Int): String =
    if (containsNonAscii(source, beginIndex, endIndex))
        source.commonToUtf8String(beginIndex, endIndex)      // today's path
    else
        String(source, beginIndex, endIndex - beginIndex, Charsets.ISO_8859_1)
```

@fzhinkin which option do you think is best?
Regards.

Resolves #515
