### PR TITLE
Avoid lambda allocation for JVM closed checks

### DIFF
--- a/core/jvm/src/SinksJvm.kt
+++ b/core/jvm/src/SinksJvm.kt
@@ -56,27 +56,20 @@ public fun Sink.writeString(string: String, charset: Charset, startIndex: Int = 
  */
 @OptIn(DelicateIoApi::class)
 public fun Sink.asOutputStream(): OutputStream {
-    val isClosed: () -> Boolean = when (this) {
-        is RealSink -> this::closed
-        is Buffer -> {
-            { false }
-        }
-    }
-
     return object : OutputStream() {
         override fun write(byte: Int) {
-            if (isClosed()) throw IOException("Underlying sink is closed.")
+            if (this@asOutputStream.isClosed()) throw IOException("Underlying sink is closed.")
             writeToInternalBuffer { it.writeByte(byte.toByte()) }
         }
 
         override fun write(data: ByteArray, offset: Int, byteCount: Int) {
-            if (isClosed()) throw IOException("Underlying sink is closed.")
+            if (this@asOutputStream.isClosed()) throw IOException("Underlying sink is closed.")
             writeToInternalBuffer { it.write(data, offset, offset + byteCount) }
         }
 
         override fun flush() {
             // For backwards compatibility, a flush() on a closed stream is a no-op.
-            if (!isClosed()) {
+            if (!this@asOutputStream.isClosed()) {
                 this@asOutputStream.flush()
             }
         }
@@ -110,23 +103,21 @@ public fun Sink.write(source: ByteBuffer): Int {
  * Returns [WritableByteChannel] backed by this sink. Closing the channel will also close the sink.
  */
 public fun Sink.asByteChannel(): WritableByteChannel {
-    val isClosed: () -> Boolean = when (this) {
-        is RealSink -> this::closed
-        is Buffer -> {
-            { false }
-        }
-    }
-
     return object : WritableByteChannel {
         override fun close() {
             this@asByteChannel.close()
         }
 
-        override fun isOpen(): Boolean = !isClosed()
+        override fun isOpen(): Boolean = !this@asByteChannel.isClosed()
 
         override fun write(source: ByteBuffer): Int {
-            check(!isClosed()) { "Underlying sink is closed." }
+            check(!this@asByteChannel.isClosed()) { "Underlying sink is closed." }
             return this@asByteChannel.write(source)
         }
     }
+}
+
+private fun Sink.isClosed(): Boolean = when (this) {
+    is RealSink -> closed
+    is Buffer -> false
 }

--- a/core/jvm/src/SourcesJvm.kt
+++ b/core/jvm/src/SourcesJvm.kt
@@ -95,16 +95,9 @@ public fun Source.readString(byteCount: Long, charset: Charset): String {
  */
 @OptIn(InternalIoApi::class)
 public fun Source.asInputStream(): InputStream {
-    val isClosed: () -> Boolean = when (this) {
-        is RealSource -> this::closed
-        is Buffer -> {
-            { false }
-        }
-    }
-
     return object : InputStream() {
         override fun read(): Int {
-            if (isClosed()) throw IOException("Underlying source is closed.")
+            if (this@asInputStream.isClosed()) throw IOException("Underlying source is closed.")
             if (exhausted()) {
                 return -1
             }
@@ -112,14 +105,14 @@ public fun Source.asInputStream(): InputStream {
         }
 
         override fun read(data: ByteArray, offset: Int, byteCount: Int): Int {
-            if (isClosed()) throw IOException("Underlying source is closed.")
+            if (this@asInputStream.isClosed()) throw IOException("Underlying source is closed.")
             checkOffsetAndCount(data.size.toLong(), offset.toLong(), byteCount.toLong())
 
             return this@asInputStream.readAtMostTo(data, offset, offset + byteCount)
         }
 
         override fun available(): Int {
-            if (isClosed()) throw IOException("Underlying source is closed.")
+            if (this@asInputStream.isClosed()) throw IOException("Underlying source is closed.")
             return minOf(buffer.size, Integer.MAX_VALUE).toInt()
         }
 
@@ -153,20 +146,18 @@ public fun Source.readAtMostTo(sink: ByteBuffer): Int {
  * Returns [ReadableByteChannel] backed by this source. Closing the source will close the source.
  */
 public fun Source.asByteChannel(): ReadableByteChannel {
-    val isClosed: () -> Boolean = when (this) {
-        is RealSource -> this::closed
-        is Buffer -> {
-            { false }
-        }
-    }
-
     return object : ReadableByteChannel {
         override fun close() {
             this@asByteChannel.close()
         }
 
-        override fun isOpen(): Boolean = !isClosed()
+        override fun isOpen(): Boolean = !this@asByteChannel.isClosed()
 
         override fun read(sink: ByteBuffer): Int = this@asByteChannel.readAtMostTo(sink)
     }
+}
+
+private fun Source.isClosed(): Boolean = when (this) {
+    is RealSource -> closed
+    is Buffer -> false
 }


### PR DESCRIPTION
The old implementation will create method ref (for `Buffer`) and a new class for `RealSink`. New implementation is single simple static method.

Reduced 4 anonymous classes

Old example (decomp with JADX):
```java
    @NotNull
    public static final ReadableByteChannel asByteChannel(@NotNull final Source $this$asByteChannel) throws NoWhenBranchMatchedException {
        Function0 function0;
        Intrinsics.checkNotNullParameter($this$asByteChannel, "<this>");
        if ($this$asByteChannel instanceof buffered) {
            function0 = (Function0) new MutablePropertyReference0Impl($this$asByteChannel) { // from class: kotlinx.io.SourcesJvmKt$asByteChannel$isClosed$1
                public Object get() {
                    return Boolean.valueOf(((buffered) this.receiver).closed);
                }

                public void set(Object value) {
                    ((buffered) this.receiver).closed = ((Boolean) value).booleanValue();
                }
            };
        } else {
            if (!($this$asByteChannel instanceof Buffer)) {
                throw new NoWhenBranchMatchedException();
            }
            function0 = SourcesJvmKt::asByteChannel$lambda$0;
        }
        final Function0 isClosed = function0;
        return new ReadableByteChannel() { // from class: kotlinx.io.SourcesJvmKt.asByteChannel.1
            @Override // java.nio.channels.Channel, java.io.Closeable, java.lang.AutoCloseable
            public void close() {
                $this$asByteChannel.close();
            }

            @Override // java.nio.channels.Channel
            public boolean isOpen() {
                return !((Boolean) isClosed.invoke()).booleanValue();
            }

            @Override // java.nio.channels.ReadableByteChannel
            public int read(ByteBuffer sink) {
                Intrinsics.checkNotNullParameter(sink, "sink");
                return SourcesJvmKt.readAtMostTo($this$asByteChannel, sink);
            }
        };
    }

    private static final boolean asByteChannel$lambda$0() {
        return false;
    }
```