### PR TITLE
Fall back to a real temporary directory when TMPDIR and TMP are unset

### DIFF
--- a/core/mingw/src/files/FileSystemMingw.kt
+++ b/core/mingw/src/files/FileSystemMingw.kt
@@ -50,6 +50,18 @@ internal actual fun mkdirImpl(path: String) {
     }
 }
 
+public actual val SystemTemporaryDirectory: Path
+    get() = Path(getenv("TMPDIR")?.toKString() ?: getenv("TMP")?.toKString() ?: windowsTemporaryDirectory())
+
+// GetTempPathA consults TMP, TEMP, USERPROFILE and the Windows directory in turn.
+private fun windowsTemporaryDirectory(): String = memScoped {
+    val buffer = allocArray<CHARVar>(MAX_PATH_LENGTH)
+    if (GetTempPathA(MAX_PATH_LENGTH.convert(), buffer) == 0u) {
+        throw IOException("GetTempPathA failed with error code: ${GetLastError()}")
+    }
+    buffer.toKString()
+}
+
 private const val MAX_PATH_LENGTH = 32767
 
 internal actual fun realpathImpl(path: String): String {

--- a/core/nativeNonApple/src/files/FileSystemNativeNonApple.kt
+++ b/core/nativeNonApple/src/files/FileSystemNativeNonApple.kt
@@ -9,10 +9,6 @@ import kotlinx.cinterop.*
 import kotlinx.io.IOException
 import platform.posix.*
 
-@OptIn(ExperimentalForeignApi::class)
-public actual val SystemTemporaryDirectory: Path
-    get() = Path(getenv("TMPDIR")?.toKString() ?: getenv("TMP")?.toKString() ?: "")
-
 @OptIn(ExperimentalForeignApi::class, UnsafeNumber::class)
 internal actual fun metadataOrNullImpl(path: Path): FileMetadata? {
     memScoped {

--- a/core/unix/src/files/FileSystemUnix.kt
+++ b/core/unix/src/files/FileSystemUnix.kt
@@ -14,6 +14,11 @@ import kotlinx.cinterop.toKString
 import kotlinx.io.IOException
 import platform.posix.*
 
+// TMPDIR is unset in most containers, systemd units and CI runners;
+// an empty fallback made every temporary path resolve against the filesystem root.
+public actual val SystemTemporaryDirectory: Path
+    get() = Path(getenv("TMPDIR")?.toKString() ?: getenv("TMP")?.toKString() ?: "/tmp")
+
 internal actual fun atomicMoveImpl(source: Path, destination: Path) {
     if (rename(source.path, destination.path) != 0) {
         throw IOException("Move failed: ${strerror(errno)?.toKString()}")


### PR DESCRIPTION
On the Linux, Android Native and MinGW targets `SystemTemporaryDirectory` is `Path("")` when neither `TMPDIR` nor `TMP` is set, which is the normal state of a container, a systemd unit or a CI runner. Every path built from it then resolves against the filesystem root: with both variables unset, `:kotlinx-io-core:linuxX64Test` fails 19 tests with `Failed to open /<name> with Permission denied`, and `SmokeFileTest.checkTmpDir` fails on `exists(SystemTemporaryDirectory)`.

The shared `nativeNonApple` actual is replaced by one per source set: `unix` falls back to `/tmp`, `mingw` falls back to `GetTempPathA`, which consults `TMP`, `TEMP`, `USERPROFILE` and the Windows directory in turn. Lookup order for a set variable is unchanged.

Verified on develop (`5b94edd1`): `env -u TMPDIR -u TMP ./gradlew :kotlinx-io-core:linuxX64Test` fails 19 of 1115 before, exits 0 after; `compileKotlinMingwX64` and `checkLegacyAbi` pass. The MinGW change is compiled here, not run.
